### PR TITLE
feat: HEIC/TIFF/BMP image upload support & optimization

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "nanoid": "^5.0.4",
         "nodemailer": "^8.0.0",
         "pg": "^8.11.3",
+        "sharp": "^0.33.5",
         "stripe": "^20.3.0",
         "zod": "^3.22.4"
       },
@@ -974,6 +975,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -1414,6 +1425,367 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -2902,6 +3274,7 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -3206,6 +3579,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3388,6 +3802,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dezalgo": {
@@ -3611,6 +4034,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4117,6 +4541,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4740,6 +5170,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",
@@ -5272,6 +5703,45 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5385,6 +5855,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/sirv": {
@@ -6336,6 +6815,7 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "node --import tsx --test src/__tests__/*.test.ts",
+    "test": "node --test src/**/*.test.js",
     "db:migrate": "node dist/db/migrate.js",
     "db:migrate:owners": "node dist/db/migrate-owners.js",
     "db:migrate:pdf-import": "node dist/db/migrate-pdf-import.js",
@@ -36,7 +36,6 @@
     "db:seed:cms:dev": "tsx src/db/seed-cms.ts",
     "db:migrate:subscriptions": "node dist/db/migrate-subscriptions.js",
     "db:migrate:subscriptions:dev": "tsx src/db/migrate-subscriptions.ts",
-    "test": "node --test src/**/*.test.js",
     "test:backend": "tsx --test src/models/health-records.test.ts"
   },
   "dependencies": {
@@ -55,6 +54,7 @@
     "nanoid": "^5.0.4",
     "nodemailer": "^8.0.0",
     "pg": "^8.11.3",
+    "sharp": "^0.33.5",
     "stripe": "^20.3.0",
     "zod": "^3.22.4"
   },

--- a/backend/src/__tests__/image-optimizer.test.ts
+++ b/backend/src/__tests__/image-optimizer.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the image-optimizer service
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import sharp from 'sharp';
+import {
+  optimizeImage,
+  replaceExtension,
+  isOptimizableImage,
+} from '../services/image-optimizer';
+
+// Helper to create a test image buffer
+async function createTestImage(
+  width: number,
+  height: number,
+  format: 'jpeg' | 'png' | 'webp' | 'gif' | 'tiff' = 'jpeg'
+): Promise<Buffer> {
+  const pipeline = sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 255, g: 0, b: 0 },
+    },
+  });
+
+  switch (format) {
+    case 'png':
+      return pipeline.png().toBuffer();
+    case 'webp':
+      return pipeline.webp().toBuffer();
+    case 'gif':
+      return pipeline.gif().toBuffer();
+    case 'tiff':
+      return pipeline.tiff().toBuffer();
+    default:
+      return pipeline.jpeg().toBuffer();
+  }
+}
+
+describe('isOptimizableImage', () => {
+  test('returns true for JPEG', () => {
+    assert.strictEqual(isOptimizableImage('image/jpeg'), true);
+  });
+
+  test('returns true for PNG', () => {
+    assert.strictEqual(isOptimizableImage('image/png'), true);
+  });
+
+  test('returns true for WebP', () => {
+    assert.strictEqual(isOptimizableImage('image/webp'), true);
+  });
+
+  test('returns true for GIF', () => {
+    assert.strictEqual(isOptimizableImage('image/gif'), true);
+  });
+
+  test('returns true for HEIC', () => {
+    assert.strictEqual(isOptimizableImage('image/heic'), true);
+  });
+
+  test('returns true for HEIF', () => {
+    assert.strictEqual(isOptimizableImage('image/heif'), true);
+  });
+
+  test('returns true for TIFF', () => {
+    assert.strictEqual(isOptimizableImage('image/tiff'), true);
+  });
+
+  test('returns true for BMP', () => {
+    assert.strictEqual(isOptimizableImage('image/bmp'), true);
+  });
+
+  test('returns true for x-ms-bmp', () => {
+    assert.strictEqual(isOptimizableImage('image/x-ms-bmp'), true);
+  });
+
+  test('returns false for PDF', () => {
+    assert.strictEqual(isOptimizableImage('application/pdf'), false);
+  });
+
+  test('returns false for text', () => {
+    assert.strictEqual(isOptimizableImage('text/plain'), false);
+  });
+});
+
+describe('optimizeImage', () => {
+  test('compresses a JPEG image', async () => {
+    const input = await createTestImage(800, 600, 'jpeg');
+    const result = await optimizeImage(input, 'image/jpeg');
+
+    assert.strictEqual(result.mimeType, 'image/jpeg');
+    assert.strictEqual(result.extension, '.jpg');
+
+    // Verify output is a valid image
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.format, 'jpeg');
+    assert.ok(metadata.width! <= 1920);
+    assert.ok(metadata.height! <= 1920);
+  });
+
+  test('resizes a large JPEG to fit within 1920px', async () => {
+    const input = await createTestImage(3000, 2000, 'jpeg');
+    const result = await optimizeImage(input, 'image/jpeg');
+
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.width, 1920);
+    // Aspect ratio should be maintained
+    assert.strictEqual(metadata.height, 1280);
+  });
+
+  test('does not enlarge a small image', async () => {
+    const input = await createTestImage(200, 150, 'jpeg');
+    const result = await optimizeImage(input, 'image/jpeg');
+
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.width, 200);
+    assert.strictEqual(metadata.height, 150);
+  });
+
+  test('keeps PNG format', async () => {
+    const input = await createTestImage(800, 600, 'png');
+    const result = await optimizeImage(input, 'image/png');
+
+    assert.strictEqual(result.mimeType, 'image/png');
+    assert.strictEqual(result.extension, '.png');
+
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.format, 'png');
+  });
+
+  test('keeps WebP format', async () => {
+    const input = await createTestImage(800, 600, 'webp');
+    const result = await optimizeImage(input, 'image/webp');
+
+    assert.strictEqual(result.mimeType, 'image/webp');
+    assert.strictEqual(result.extension, '.webp');
+
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.format, 'webp');
+  });
+
+  test('keeps GIF format', async () => {
+    const input = await createTestImage(800, 600, 'gif');
+    const result = await optimizeImage(input, 'image/gif');
+
+    assert.strictEqual(result.mimeType, 'image/gif');
+    assert.strictEqual(result.extension, '.gif');
+
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.format, 'gif');
+  });
+
+  test('converts TIFF to JPEG', async () => {
+    const input = await createTestImage(800, 600, 'tiff');
+    const result = await optimizeImage(input, 'image/tiff');
+
+    assert.strictEqual(result.mimeType, 'image/jpeg');
+    assert.strictEqual(result.extension, '.jpg');
+
+    const metadata = await sharp(result.buffer).metadata();
+    assert.strictEqual(metadata.format, 'jpeg');
+  });
+
+  test('passes through non-image types unchanged', async () => {
+    const input = Buffer.from('fake pdf content');
+    const result = await optimizeImage(input, 'application/pdf');
+
+    assert.strictEqual(result.mimeType, 'application/pdf');
+    assert.strictEqual(result.extension, '.pdf');
+    assert.deepStrictEqual(result.buffer, input);
+  });
+});
+
+describe('replaceExtension', () => {
+  test('replaces .heic with .jpg', () => {
+    assert.strictEqual(replaceExtension('photo.heic', '.jpg'), 'photo.jpg');
+  });
+
+  test('replaces .HEIC with .jpg (preserves name case)', () => {
+    assert.strictEqual(replaceExtension('Photo.HEIC', '.jpg'), 'Photo.jpg');
+  });
+
+  test('replaces .tiff with .jpg', () => {
+    assert.strictEqual(replaceExtension('scan.tiff', '.jpg'), 'scan.jpg');
+  });
+
+  test('replaces .bmp with .jpg', () => {
+    assert.strictEqual(replaceExtension('image.bmp', '.jpg'), 'image.jpg');
+  });
+
+  test('handles filenames with multiple dots', () => {
+    assert.strictEqual(replaceExtension('my.photo.heic', '.jpg'), 'my.photo.jpg');
+  });
+
+  test('handles filenames with no extension', () => {
+    assert.strictEqual(replaceExtension('photo', '.jpg'), 'photo.jpg');
+  });
+});

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -62,7 +62,17 @@ export const config = {
   imageUpload: {
     maxSizeMB: parseInt(process.env.IMAGE_MAX_SIZE_MB || '10', 10),
     uploadDir: process.env.IMAGE_UPLOAD_DIR || 'uploads/images',
-    allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
+    allowedMimeTypes: [
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'image/gif',
+      'image/heic',
+      'image/heif',
+      'image/tiff',
+      'image/bmp',
+      'image/x-ms-bmp',
+    ],
   },
 
   documentUpload: {
@@ -74,6 +84,11 @@ export const config = {
       'image/png',
       'image/webp',
       'image/gif',
+      'image/heic',
+      'image/heif',
+      'image/tiff',
+      'image/bmp',
+      'image/x-ms-bmp',
     ],
   },
 

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -4,13 +4,14 @@ import { config } from '../config/index.js';
 // Use memory storage so we can pass buffer to storage adapter
 const memoryStorage = multer.memoryStorage();
 
-// File filter for images only
+// File filter for images only (uses config for allowed types)
 const imageFilter = (req: any, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-  if (allowedTypes.includes(file.mimetype)) {
+  if (config.imageUpload.allowedMimeTypes.includes(file.mimetype)) {
     cb(null, true);
   } else {
-    cb(new Error('Invalid file type. Only JPEG, PNG, GIF, and WebP are allowed.'));
+    cb(new Error(
+      'Invalid file type. Supported image formats: JPEG, PNG, GIF, WebP, HEIC, TIFF, and BMP.'
+    ));
   }
 };
 
@@ -23,28 +24,23 @@ const pdfFilter = (req: any, file: Express.Multer.File, cb: multer.FileFilterCal
   }
 };
 
-// File filter for documents (PDFs + images)
+// File filter for documents (PDFs + images, uses config)
 const documentFilter = (req: any, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
-  const allowedTypes = [
-    'application/pdf',
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-    'image/gif',
-  ];
-  if (allowedTypes.includes(file.mimetype)) {
+  if (config.documentUpload.allowedMimeTypes.includes(file.mimetype)) {
     cb(null, true);
   } else {
-    cb(new Error('Invalid file type. Only PDF, JPEG, PNG, WebP, and GIF files are allowed.'));
+    cb(new Error(
+      'Invalid file type. Supported formats: PDF, JPEG, PNG, WebP, GIF, HEIC, TIFF, and BMP.'
+    ));
   }
 };
 
-// Pet photo upload - 5MB, images only
+// Pet photo upload - 10MB, images only
 export const uploadPhoto = multer({
   storage: memoryStorage,
   fileFilter: imageFilter,
   limits: {
-    fileSize: 5 * 1024 * 1024, // 5MB
+    fileSize: config.imageUpload.maxSizeMB * 1024 * 1024,
   },
 });
 

--- a/backend/src/routes/document-import.ts
+++ b/backend/src/routes/document-import.ts
@@ -5,6 +5,7 @@ import { requireFeature } from '../middleware/subscription.js';
 import { storage } from '../services/storage.js';
 import { userHasPetAccess, userCanEditPet } from '../models/pet-owners.js';
 import { findPetById } from '../models/pet.js';
+import { optimizeImage, replaceExtension, isOptimizableImage } from '../services/image-optimizer.js';
 import {
   createDocumentUpload,
   getDocumentUploadById,
@@ -70,12 +71,28 @@ router.post('/:petId/documents/upload', authenticate, requireFeature('upload'), 
       return;
     }
 
+    // Optimize images before storage (skip PDFs)
+    let fileBuffer = req.file.buffer;
+    let fileMimeType = req.file.mimetype;
+    let fileName = req.file.originalname;
+    let fileSize = req.file.size;
+
+    if (isOptimizableImage(req.file.mimetype)) {
+      const optimized = await optimizeImage(req.file.buffer, req.file.mimetype);
+      fileBuffer = optimized.buffer;
+      fileSize = optimized.buffer.length;
+      if (optimized.mimeType !== req.file.mimetype) {
+        fileName = replaceExtension(req.file.originalname, optimized.extension);
+      }
+      fileMimeType = optimized.mimeType;
+    }
+
     // Upload to storage
-    const uploadResult = await storage.upload(req.file.buffer, {
+    const uploadResult = await storage.upload(fileBuffer, {
       type: 'documents',
       petId,
-      originalFilename: req.file.originalname,
-      mimeType: req.file.mimetype,
+      originalFilename: fileName,
+      mimeType: fileMimeType,
     });
 
     // Create document upload record
@@ -85,9 +102,9 @@ router.post('/:petId/documents/upload', authenticate, requireFeature('upload'), 
       filename: uploadResult.key,
       originalFilename: req.file.originalname,
       filePath: uploadResult.filePath,
-      fileSize: req.file.size,
-      mimeType: req.file.mimetype,
-      mediaType: getMediaTypeFromMime(req.file.mimetype),
+      fileSize,
+      mimeType: fileMimeType,
+      mediaType: getMediaTypeFromMime(fileMimeType),
     });
 
     // Process the document (classify and extract)

--- a/backend/src/routes/photo-import.ts
+++ b/backend/src/routes/photo-import.ts
@@ -4,6 +4,7 @@ import { uploadImage } from '../middleware/upload.js';
 import { storage } from '../services/storage.js';
 import { userHasPetAccess, userCanEditPet } from '../models/pet-owners.js';
 import { findPetById } from '../models/pet.js';
+import { optimizeImage, replaceExtension, isOptimizableImage } from '../services/image-optimizer.js';
 import {
   createImageUpload,
   getImageUploadById,
@@ -57,12 +58,18 @@ router.post('/:petId/photo-import/upload', authenticate, pdfUploadRateLimit, upl
       return;
     }
 
+    // Optimize image before storage (resize, compress, convert HEIC/TIFF/BMP to JPEG)
+    const optimized = await optimizeImage(req.file.buffer, req.file.mimetype);
+    const filename = optimized.mimeType !== req.file.mimetype
+      ? replaceExtension(req.file.originalname, optimized.extension)
+      : req.file.originalname;
+
     // Upload to storage
-    const uploadResult = await storage.upload(req.file.buffer, {
+    const uploadResult = await storage.upload(optimized.buffer, {
       type: 'images',
       petId,
-      originalFilename: req.file.originalname,
-      mimeType: req.file.mimetype,
+      originalFilename: filename,
+      mimeType: optimized.mimeType,
     });
 
     // Create image upload record
@@ -72,8 +79,8 @@ router.post('/:petId/photo-import/upload', authenticate, pdfUploadRateLimit, upl
       filename: uploadResult.key,
       originalFilename: req.file.originalname,
       filePath: uploadResult.filePath,
-      fileSize: req.file.size,
-      mimeType: req.file.mimetype,
+      fileSize: optimized.buffer.length,
+      mimeType: optimized.mimeType,
       documentType: req.body.documentType,
     });
 

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -3,6 +3,7 @@ import { authenticate, AuthRequest } from '../middleware/auth.js';
 import { uploadPhoto } from '../middleware/upload.js';
 import { storage } from '../services/storage.js';
 import { findPetById, updatePet } from '../models/pet.js';
+import { optimizeImage, replaceExtension, isOptimizableImage } from '../services/image-optimizer.js';
 
 const router = Router();
 
@@ -39,12 +40,18 @@ router.post('/pet/:petId/photo', authenticate, uploadPhoto.single('photo'), asyn
       }
     }
 
-    // Upload new photo using storage adapter
-    const result = await storage.upload(req.file.buffer, {
+    // Optimize image before storage (resize, compress, convert HEIC/TIFF/BMP to JPEG)
+    const optimized = await optimizeImage(req.file.buffer, req.file.mimetype);
+    const filename = optimized.mimeType !== req.file.mimetype
+      ? replaceExtension(req.file.originalname, optimized.extension)
+      : req.file.originalname;
+
+    // Upload optimized photo using storage adapter
+    const result = await storage.upload(optimized.buffer, {
       type: 'photos',
       petId,
-      originalFilename: req.file.originalname,
-      mimeType: req.file.mimetype,
+      originalFilename: filename,
+      mimeType: optimized.mimeType,
     });
 
     // Update pet with new photo URL

--- a/backend/src/services/image-optimizer.ts
+++ b/backend/src/services/image-optimizer.ts
@@ -1,0 +1,102 @@
+import sharp from 'sharp';
+import path from 'path';
+
+const MAX_DIMENSION = 1920;
+const JPEG_QUALITY = 80;
+
+// MIME types that should be converted to JPEG
+const CONVERT_TO_JPEG: Set<string> = new Set([
+  'image/heic',
+  'image/heif',
+  'image/tiff',
+  'image/bmp',
+  'image/x-ms-bmp',
+]);
+
+// Image MIME types we optimize (resize/compress) but keep in their original format
+const KEEP_FORMAT: Set<string> = new Set([
+  'image/png',
+  'image/webp',
+  'image/gif',
+]);
+
+export interface OptimizeResult {
+  buffer: Buffer;
+  mimeType: string;
+  extension: string;
+}
+
+/**
+ * Returns true if the given MIME type is an image type we can optimize.
+ */
+export function isOptimizableImage(mimeType: string): boolean {
+  return (
+    mimeType === 'image/jpeg' ||
+    CONVERT_TO_JPEG.has(mimeType) ||
+    KEEP_FORMAT.has(mimeType)
+  );
+}
+
+/**
+ * Optimize an image buffer: auto-rotate, resize to fit within MAX_DIMENSION,
+ * and convert HEIC/TIFF/BMP to JPEG. JPEGs are re-compressed. PNG/WebP/GIF
+ * are resized but kept in their original format.
+ */
+export async function optimizeImage(
+  buffer: Buffer,
+  mimeType: string
+): Promise<OptimizeResult> {
+  // If not an optimizable image, return as-is
+  if (!isOptimizableImage(mimeType)) {
+    const ext = mimeType === 'application/pdf' ? '.pdf' : '';
+    return { buffer, mimeType, extension: ext };
+  }
+
+  let pipeline = sharp(buffer).rotate(); // auto-rotate using EXIF
+
+  // Resize to fit within max dimensions, preserving aspect ratio
+  pipeline = pipeline.resize(MAX_DIMENSION, MAX_DIMENSION, {
+    fit: 'inside',
+    withoutEnlargement: true,
+  });
+
+  if (CONVERT_TO_JPEG.has(mimeType) || mimeType === 'image/jpeg') {
+    // Convert to JPEG
+    pipeline = pipeline.jpeg({ quality: JPEG_QUALITY });
+    const outputBuffer = await pipeline.toBuffer();
+    return { buffer: outputBuffer, mimeType: 'image/jpeg', extension: '.jpg' };
+  }
+
+  if (mimeType === 'image/png') {
+    pipeline = pipeline.png();
+    const outputBuffer = await pipeline.toBuffer();
+    return { buffer: outputBuffer, mimeType: 'image/png', extension: '.png' };
+  }
+
+  if (mimeType === 'image/webp') {
+    pipeline = pipeline.webp({ quality: JPEG_QUALITY });
+    const outputBuffer = await pipeline.toBuffer();
+    return { buffer: outputBuffer, mimeType: 'image/webp', extension: '.webp' };
+  }
+
+  if (mimeType === 'image/gif') {
+    // GIF: just resize, keep format
+    pipeline = pipeline.gif();
+    const outputBuffer = await pipeline.toBuffer();
+    return { buffer: outputBuffer, mimeType: 'image/gif', extension: '.gif' };
+  }
+
+  // Fallback: shouldn't reach here, but convert to JPEG
+  pipeline = pipeline.jpeg({ quality: JPEG_QUALITY });
+  const outputBuffer = await pipeline.toBuffer();
+  return { buffer: outputBuffer, mimeType: 'image/jpeg', extension: '.jpg' };
+}
+
+/**
+ * Replace the file extension in a filename.
+ * e.g. replaceExtension('photo.heic', '.jpg') → 'photo.jpg'
+ */
+export function replaceExtension(filename: string, newExtension: string): string {
+  const parsed = path.parse(filename);
+  return `${parsed.name}${newExtension}`;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -75,6 +75,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -343,6 +344,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1268,6 +1270,7 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-5.10.0.tgz",
       "integrity": "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -1337,6 +1340,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1494,6 +1498,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1898,6 +1903,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2188,6 +2194,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2377,6 +2384,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2389,6 +2397,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2736,6 +2745,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2827,6 +2837,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/PhotoUpload.tsx
+++ b/frontend/src/components/PhotoUpload.tsx
@@ -24,16 +24,24 @@ export default function PhotoUpload({ petId, currentPhotoUrl, onPhotoUpdated }: 
     const file = e.target.files?.[0];
     if (!file || !token) return;
 
-    // Validate file type
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-    if (!allowedTypes.includes(file.type)) {
-      setError('Please select a valid image file (JPEG, PNG, GIF, or WebP)');
+    // Validate file type (check MIME type with extension fallback for HEIC)
+    const allowedTypes = [
+      'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+      'image/heic', 'image/heif', 'image/tiff', 'image/bmp', 'image/x-ms-bmp',
+    ];
+    const allowedExtensions = [
+      '.jpg', '.jpeg', '.png', '.gif', '.webp',
+      '.heic', '.heif', '.tiff', '.tif', '.bmp',
+    ];
+    const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+    if (!allowedTypes.includes(file.type) && !allowedExtensions.includes(ext)) {
+      setError('Please select a valid image file (JPEG, PNG, GIF, WebP, HEIC, TIFF, or BMP)');
       return;
     }
 
-    // Validate file size (5MB)
-    if (file.size > 5 * 1024 * 1024) {
-      setError('File size must be less than 5MB');
+    // Validate file size (10MB)
+    if (file.size > 10 * 1024 * 1024) {
+      setError('File size must be less than 10MB');
       return;
     }
 
@@ -124,7 +132,7 @@ export default function PhotoUpload({ petId, currentPhotoUrl, onPhotoUpdated }: 
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/jpeg,image/png,image/gif,image/webp"
+            accept="image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif,image/tiff,image/bmp,.heic,.heif,.tiff,.tif,.bmp"
             onChange={handleFileSelect}
             className="hidden"
             disabled={isUploading}
@@ -141,6 +149,8 @@ export default function PhotoUpload({ petId, currentPhotoUrl, onPhotoUpdated }: 
           </button>
         )}
       </div>
+
+      <p className="text-xs text-gray-400 mt-1">JPEG, PNG, WebP, GIF, HEIC, TIFF, BMP up to 10MB</p>
 
       {error && <p className="error-text mt-2">{error}</p>}
     </div>

--- a/frontend/src/components/document-import/DocumentUploadZone.tsx
+++ b/frontend/src/components/document-import/DocumentUploadZone.tsx
@@ -14,6 +14,15 @@ const ACCEPTED_TYPES = [
   'image/png',
   'image/webp',
   'image/gif',
+  'image/heic',
+  'image/heif',
+  'image/tiff',
+  'image/bmp',
+  'image/x-ms-bmp',
+];
+const ACCEPTED_EXTENSIONS = [
+  '.pdf', '.jpg', '.jpeg', '.png', '.gif', '.webp',
+  '.heic', '.heif', '.tiff', '.tif', '.bmp',
 ];
 
 export function DocumentUploadZone({ petId, onUploadComplete, disabled }: DocumentUploadZoneProps) {
@@ -43,10 +52,13 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
     if (disabled) return;
 
     const files = Array.from(e.dataTransfer.files);
-    const validFile = files.find(f => ACCEPTED_TYPES.includes(f.type));
+    const validFile = files.find(f => {
+      const ext = '.' + f.name.split('.').pop()?.toLowerCase();
+      return ACCEPTED_TYPES.includes(f.type) || ACCEPTED_EXTENSIONS.includes(ext);
+    });
 
     if (!validFile) {
-      setError('Please drop a PDF or image file (JPEG, PNG, WebP, GIF)');
+      setError('Please drop a PDF or image file (JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP)');
       return;
     }
 
@@ -57,8 +69,9 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
     const file = e.target.files?.[0];
     if (!file) return;
 
-    if (!ACCEPTED_TYPES.includes(file.type)) {
-      setError('Please select a PDF or image file (JPEG, PNG, WebP, GIF)');
+    const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+    if (!ACCEPTED_TYPES.includes(file.type) && !ACCEPTED_EXTENSIONS.includes(ext)) {
+      setError('Please select a PDF or image file (JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP)');
       return;
     }
 
@@ -69,8 +82,9 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
   const uploadFile = async (file: File) => {
     if (!token) return;
 
-    // Show preview for images
-    if (file.type.startsWith('image/')) {
+    // Show preview for images (skip HEIC/TIFF/BMP which browsers can't display)
+    const nonPreviewable = ['image/heic', 'image/heif', 'image/tiff', 'image/bmp', 'image/x-ms-bmp'];
+    if (file.type.startsWith('image/') && !nonPreviewable.includes(file.type)) {
       const reader = new FileReader();
       reader.onload = (e) => {
         setPreviewUrl(e.target?.result as string);
@@ -154,7 +168,7 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                 <span>Upload a document</span>
                 <input
                   type="file"
-                  accept=".pdf,image/jpeg,image/png,image/webp,image/gif"
+                  accept=".pdf,image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,image/tiff,image/bmp,.heic,.heif,.tiff,.tif,.bmp"
                   onChange={handleFileSelect}
                   className="sr-only"
                   disabled={isDisabled}
@@ -163,7 +177,7 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
               {' '}or drag and drop
             </p>
             <p className="mt-1 text-xs text-gray-500">
-              PDFs and images (JPEG, PNG, WebP, GIF) up to 20MB
+              PDFs and images (JPEG, PNG, WebP, GIF, HEIC, TIFF, BMP) up to 20MB
             </p>
             <p className="mt-2 text-xs text-gray-400">
               We'll automatically detect what type of document it is

--- a/frontend/src/components/photo-import/ImageUploadZone.tsx
+++ b/frontend/src/components/photo-import/ImageUploadZone.tsx
@@ -7,7 +7,14 @@ interface ImageUploadZoneProps {
   onUploadComplete: (upload: ImageUpload) => void;
 }
 
-const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const ACCEPTED_TYPES = [
+  'image/jpeg', 'image/png', 'image/webp', 'image/gif',
+  'image/heic', 'image/heif', 'image/tiff', 'image/bmp', 'image/x-ms-bmp',
+];
+const ACCEPTED_EXTENSIONS = [
+  '.jpg', '.jpeg', '.png', '.gif', '.webp',
+  '.heic', '.heif', '.tiff', '.tif', '.bmp',
+];
 
 export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProps) {
   const { token } = useAuth();
@@ -32,10 +39,13 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
     setIsDragOver(false);
 
     const files = Array.from(e.dataTransfer.files);
-    const imageFile = files.find(f => ACCEPTED_TYPES.includes(f.type));
+    const imageFile = files.find(f => {
+      const ext = '.' + f.name.split('.').pop()?.toLowerCase();
+      return ACCEPTED_TYPES.includes(f.type) || ACCEPTED_EXTENSIONS.includes(ext);
+    });
 
     if (!imageFile) {
-      setError('Please drop an image file (JPEG, PNG, WebP, or GIF)');
+      setError('Please drop an image file (JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP)');
       return;
     }
 
@@ -46,8 +56,9 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
     const file = e.target.files?.[0];
     if (!file) return;
 
-    if (!ACCEPTED_TYPES.includes(file.type)) {
-      setError('Please select an image file (JPEG, PNG, WebP, or GIF)');
+    const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+    if (!ACCEPTED_TYPES.includes(file.type) && !ACCEPTED_EXTENSIONS.includes(ext)) {
+      setError('Please select an image file (JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP)');
       return;
     }
 
@@ -58,12 +69,15 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
   const uploadFile = async (file: File) => {
     if (!token) return;
 
-    // Show preview
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      setPreviewUrl(e.target?.result as string);
-    };
-    reader.readAsDataURL(file);
+    // Show preview (skip for HEIC/TIFF/BMP which browsers can't display)
+    const nonPreviewable = ['image/heic', 'image/heif', 'image/tiff', 'image/bmp', 'image/x-ms-bmp'];
+    if (!nonPreviewable.includes(file.type)) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        setPreviewUrl(e.target?.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
 
     setIsUploading(true);
     setError(null);
@@ -142,7 +156,7 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
                 <span>Take a photo or upload an image</span>
                 <input
                   type="file"
-                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,image/tiff,image/bmp,.heic,.heif,.tiff,.tif,.bmp"
                   capture="environment"
                   onChange={handleFileSelect}
                   className="sr-only"
@@ -151,7 +165,7 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
               </label>
               {' '}or drag and drop
             </p>
-            <p className="mt-1 text-xs text-gray-500">JPEG, PNG, WebP, or GIF up to 10MB</p>
+            <p className="mt-1 text-xs text-gray-500">JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP up to 10MB</p>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add `sharp`-based image optimization service that converts HEIC/HEIF, TIFF, and BMP uploads to JPEG, resizes to max 1920px, and compresses at 80% quality
- Integrate optimization across all three upload flows: pet photo, medical image import, and document import (images only, PDFs pass through)
- Update frontend components with new accepted types, extension-based fallback validation (for browsers that don't report HEIC MIME), and format help text
- Add 25 unit tests for the image-optimizer service (all passing)

Closes #49

## Changes
### Backend
- **`sharp` dependency** added (v0.33.5)
- **New `image-optimizer.ts` service** — `optimizeImage()`, `replaceExtension()`, `isOptimizableImage()`
- **Config** — HEIC/HEIF/TIFF/BMP MIME types added to `imageUpload` and `documentUpload` allowed lists
- **Upload middleware** — uses config-driven allowed types instead of hardcoded arrays; pet photo limit now 10MB
- **Upload routes** — all three call `optimizeImage()` before storage

### Frontend
- **PhotoUpload, ImageUploadZone, DocumentUploadZone** — new types in `accept` attrs, extension fallback validation, preview skipped for non-displayable types, updated help text

## Test plan
- [ ] Upload a HEIC file as pet photo → accepts, converts to JPEG, stores optimized
- [ ] Upload a large iPhone JPEG (>5MB) as pet photo → accepts (10MB limit), serves optimized
- [ ] Upload TIFF and BMP via document importer → converts to JPEG
- [ ] Upload a PDF via document importer → passes through unchanged (no optimization)
- [ ] Try uploading an unsupported type (e.g., .exe) → clear error message
- [ ] Verify `npm run build` succeeds for backend
- [ ] Verify frontend build succeeds
- [ ] Run `npx tsx --test src/__tests__/image-optimizer.test.ts` → 25/25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)