### PR TITLE
feat: inline editing & delete confirmation for all pet profile tabs

### DIFF
--- a/backend/src/models/health-records.ts
+++ b/backend/src/models/health-records.ts
@@ -333,6 +333,42 @@ export async function getPetAllergies(petId: number): Promise<PetAllergy[]> {
   return query<PetAllergy>('SELECT * FROM pet_allergies WHERE pet_id = $1 ORDER BY created_at DESC', [petId]);
 }
 
+export async function updatePetAllergy(id: number, petId: number, updates: Partial<Omit<PetAllergy, 'id' | 'pet_id' | 'created_at'>>, audit?: AuditContext): Promise<PetAllergy | null> {
+  const existing = await queryOne<PetAllergy>('SELECT * FROM pet_allergies WHERE id = $1 AND pet_id = $2', [id, petId]);
+
+  const fields: string[] = [];
+  const values: any[] = [];
+  let paramCount = 1;
+
+  const allowedFields = ['allergen', 'reaction', 'severity'];
+
+  for (const field of allowedFields) {
+    if ((updates as any)[field] !== undefined) {
+      fields.push(`${field} = $${paramCount++}`);
+      values.push((updates as any)[field]);
+    }
+  }
+
+  if (fields.length === 0) return null;
+
+  values.push(id, petId);
+
+  const result = await queryOne<PetAllergy>(
+    `UPDATE pet_allergies SET ${fields.join(', ')} WHERE id = $${paramCount} AND pet_id = $${paramCount + 1} RETURNING *`,
+    values
+  );
+
+  if (audit && existing && result) {
+    await logUpdate('pet_allergies', id, existing, result, audit.userId, {
+      source: audit.source,
+      ipAddress: audit.ipAddress,
+      userAgent: audit.userAgent,
+    });
+  }
+
+  return result;
+}
+
 export async function deletePetAllergy(id: number, petId: number, audit?: AuditContext): Promise<boolean> {
   const existing = await queryOne<PetAllergy>('SELECT * FROM pet_allergies WHERE id = $1 AND pet_id = $2', [id, petId]);
 
@@ -518,6 +554,42 @@ export async function getPetVaccinations(petId: number): Promise<PetVaccination[
   return query<PetVaccination>('SELECT * FROM pet_vaccinations WHERE pet_id = $1 ORDER BY administered_date DESC', [petId]);
 }
 
+export async function updatePetVaccination(id: number, petId: number, updates: Partial<Omit<PetVaccination, 'id' | 'pet_id' | 'created_at'>>, audit?: AuditContext): Promise<PetVaccination | null> {
+  const existing = await queryOne<PetVaccination>('SELECT * FROM pet_vaccinations WHERE id = $1 AND pet_id = $2', [id, petId]);
+
+  const fields: string[] = [];
+  const values: any[] = [];
+  let paramCount = 1;
+
+  const allowedFields = ['name', 'administered_date', 'expiration_date', 'administered_by', 'lot_number'];
+
+  for (const field of allowedFields) {
+    if ((updates as any)[field] !== undefined) {
+      fields.push(`${field} = $${paramCount++}`);
+      values.push((updates as any)[field]);
+    }
+  }
+
+  if (fields.length === 0) return null;
+
+  values.push(id, petId);
+
+  const result = await queryOne<PetVaccination>(
+    `UPDATE pet_vaccinations SET ${fields.join(', ')} WHERE id = $${paramCount} AND pet_id = $${paramCount + 1} RETURNING *`,
+    values
+  );
+
+  if (audit && existing && result) {
+    await logUpdate('pet_vaccinations', id, existing, result, audit.userId, {
+      source: audit.source,
+      ipAddress: audit.ipAddress,
+      userAgent: audit.userAgent,
+    });
+  }
+
+  return result;
+}
+
 export async function deletePetVaccination(id: number, petId: number, audit?: AuditContext): Promise<boolean> {
   const existing = await queryOne<PetVaccination>('SELECT * FROM pet_vaccinations WHERE id = $1 AND pet_id = $2', [id, petId]);
 
@@ -567,6 +639,42 @@ export async function createPetEmergencyContact(petId: number, data: Omit<PetEme
 
 export async function getPetEmergencyContacts(petId: number): Promise<PetEmergencyContact[]> {
   return query<PetEmergencyContact>('SELECT * FROM pet_emergency_contacts WHERE pet_id = $1 ORDER BY is_primary DESC, created_at', [petId]);
+}
+
+export async function updatePetEmergencyContact(id: number, petId: number, updates: Partial<Omit<PetEmergencyContact, 'id' | 'pet_id' | 'created_at'>>, audit?: AuditContext): Promise<PetEmergencyContact | null> {
+  const existing = await queryOne<PetEmergencyContact>('SELECT * FROM pet_emergency_contacts WHERE id = $1 AND pet_id = $2', [id, petId]);
+
+  const fields: string[] = [];
+  const values: any[] = [];
+  let paramCount = 1;
+
+  const allowedFields = ['name', 'relationship', 'phone', 'email', 'is_primary'];
+
+  for (const field of allowedFields) {
+    if ((updates as any)[field] !== undefined) {
+      fields.push(`${field} = $${paramCount++}`);
+      values.push((updates as any)[field]);
+    }
+  }
+
+  if (fields.length === 0) return null;
+
+  values.push(id, petId);
+
+  const result = await queryOne<PetEmergencyContact>(
+    `UPDATE pet_emergency_contacts SET ${fields.join(', ')} WHERE id = $${paramCount} AND pet_id = $${paramCount + 1} RETURNING *`,
+    values
+  );
+
+  if (audit && existing && result) {
+    await logUpdate('pet_emergency_contacts', id, existing, result, audit.userId, {
+      source: audit.source,
+      ipAddress: audit.ipAddress,
+      userAgent: audit.userAgent,
+    });
+  }
+
+  return result;
 }
 
 export async function deletePetEmergencyContact(id: number, petId: number, audit?: AuditContext): Promise<boolean> {

--- a/backend/src/routes/pets.ts
+++ b/backend/src/routes/pets.ts
@@ -19,12 +19,12 @@ import {
   getUserPetRole,
 } from '../models/pet-owners.js';
 import {
-  getPetVets, createPetVet, deletePetVet, setPrimaryVet,
-  getPetConditions, createPetCondition, deletePetCondition,
-  getPetAllergies, createPetAllergy, deletePetAllergy,
+  getPetVets, createPetVet, updatePetVet, deletePetVet, setPrimaryVet,
+  getPetConditions, createPetCondition, updatePetCondition, deletePetCondition,
+  getPetAllergies, createPetAllergy, updatePetAllergy, deletePetAllergy,
   getPetMedications, createPetMedication, updatePetMedication, deletePetMedication,
-  getPetVaccinations, createPetVaccination, deletePetVaccination,
-  getPetEmergencyContacts, createPetEmergencyContact, deletePetEmergencyContact,
+  getPetVaccinations, createPetVaccination, updatePetVaccination, deletePetVaccination,
+  getPetEmergencyContacts, createPetEmergencyContact, updatePetEmergencyContact, deletePetEmergencyContact,
 } from '../models/health-records.js';
 
 const router = Router();
@@ -199,6 +199,24 @@ router.delete('/:id/vets/:vetId', authenticate, async (req: AuthRequest, res: Re
   }
 });
 
+router.patch('/:id/vets/:vetId', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
+      res.status(404).json({ error: 'Pet not found' });
+      return;
+    }
+    const audit = { userId: req.userId!, source: 'manual' as const, ipAddress: req.ip, userAgent: req.headers['user-agent'] };
+    const vet = await updatePetVet(parseInt(req.params.vetId), parseInt(req.params.id), req.body, audit);
+    if (!vet) {
+      res.status(404).json({ error: 'Veterinarian not found' });
+      return;
+    }
+    res.json(vet);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update veterinarian' });
+  }
+});
+
 router.patch('/:id/vets/:vetId/primary', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const petId = parseInt(req.params.id);
@@ -256,6 +274,24 @@ router.post('/:id/conditions', authenticate, async (req: AuthRequest, res: Respo
   }
 });
 
+router.patch('/:id/conditions/:conditionId', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
+      res.status(404).json({ error: 'Pet not found' });
+      return;
+    }
+    const audit = { userId: req.userId!, source: 'manual' as const, ipAddress: req.ip, userAgent: req.headers['user-agent'] };
+    const condition = await updatePetCondition(parseInt(req.params.conditionId), parseInt(req.params.id), req.body, audit);
+    if (!condition) {
+      res.status(404).json({ error: 'Condition not found' });
+      return;
+    }
+    res.json(condition);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update condition' });
+  }
+});
+
 router.delete('/:id/conditions/:conditionId', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
@@ -293,6 +329,24 @@ router.post('/:id/allergies', authenticate, async (req: AuthRequest, res: Respon
     res.status(201).json(allergy);
   } catch (error) {
     res.status(500).json({ error: 'Failed to add allergy' });
+  }
+});
+
+router.patch('/:id/allergies/:allergyId', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
+      res.status(404).json({ error: 'Pet not found' });
+      return;
+    }
+    const audit = { userId: req.userId!, source: 'manual' as const, ipAddress: req.ip, userAgent: req.headers['user-agent'] };
+    const allergy = await updatePetAllergy(parseInt(req.params.allergyId), parseInt(req.params.id), req.body, audit);
+    if (!allergy) {
+      res.status(404).json({ error: 'Allergy not found' });
+      return;
+    }
+    res.json(allergy);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update allergy' });
   }
 });
 
@@ -393,6 +447,24 @@ router.post('/:id/vaccinations', authenticate, async (req: AuthRequest, res: Res
   }
 });
 
+router.patch('/:id/vaccinations/:vacId', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
+      res.status(404).json({ error: 'Pet not found' });
+      return;
+    }
+    const audit = { userId: req.userId!, source: 'manual' as const, ipAddress: req.ip, userAgent: req.headers['user-agent'] };
+    const vaccination = await updatePetVaccination(parseInt(req.params.vacId), parseInt(req.params.id), req.body, audit);
+    if (!vaccination) {
+      res.status(404).json({ error: 'Vaccination not found' });
+      return;
+    }
+    res.json(vaccination);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update vaccination' });
+  }
+});
+
 router.delete('/:id/vaccinations/:vacId', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
@@ -430,6 +502,24 @@ router.post('/:id/emergency-contacts', authenticate, async (req: AuthRequest, re
     res.status(201).json(contact);
   } catch (error) {
     res.status(500).json({ error: 'Failed to add emergency contact' });
+  }
+});
+
+router.patch('/:id/emergency-contacts/:contactId', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    if (!await verifyPetAccess(parseInt(req.params.id), req.userId!)) {
+      res.status(404).json({ error: 'Pet not found' });
+      return;
+    }
+    const audit = { userId: req.userId!, source: 'manual' as const, ipAddress: req.ip, userAgent: req.headers['user-agent'] };
+    const contact = await updatePetEmergencyContact(parseInt(req.params.contactId), parseInt(req.params.id), req.body, audit);
+    if (!contact) {
+      res.status(404).json({ error: 'Emergency contact not found' });
+      return;
+    }
+    res.json(contact);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update emergency contact' });
   }
 });
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -104,6 +104,8 @@ export const petsApi = {
     api.get<PetVet[]>(`/api/pets/${petId}/vets`, token),
   addVet: (petId: number, data: Omit<PetVet, 'id' | 'pet_id' | 'created_at'>, token: string) =>
     api.post<PetVet>(`/api/pets/${petId}/vets`, data, token),
+  updateVet: (petId: number, vetId: number, data: Partial<PetVet>, token: string) =>
+    api.patch<PetVet>(`/api/pets/${petId}/vets/${vetId}`, data, token),
   deleteVet: (petId: number, vetId: number, token: string) =>
     api.delete(`/api/pets/${petId}/vets/${vetId}`, token),
   setPrimaryVet: (petId: number, vetId: number, token: string) =>
@@ -113,6 +115,8 @@ export const petsApi = {
     api.get<PetCondition[]>(`/api/pets/${petId}/conditions`, token),
   addCondition: (petId: number, data: Omit<PetCondition, 'id' | 'pet_id' | 'created_at'>, token: string) =>
     api.post<PetCondition>(`/api/pets/${petId}/conditions`, data, token),
+  updateCondition: (petId: number, conditionId: number, data: Partial<PetCondition>, token: string) =>
+    api.patch<PetCondition>(`/api/pets/${petId}/conditions/${conditionId}`, data, token),
   deleteCondition: (petId: number, conditionId: number, token: string) =>
     api.delete(`/api/pets/${petId}/conditions/${conditionId}`, token),
 
@@ -120,6 +124,8 @@ export const petsApi = {
     api.get<PetAllergy[]>(`/api/pets/${petId}/allergies`, token),
   addAllergy: (petId: number, data: Omit<PetAllergy, 'id' | 'pet_id' | 'created_at'>, token: string) =>
     api.post<PetAllergy>(`/api/pets/${petId}/allergies`, data, token),
+  updateAllergy: (petId: number, allergyId: number, data: Partial<PetAllergy>, token: string) =>
+    api.patch<PetAllergy>(`/api/pets/${petId}/allergies/${allergyId}`, data, token),
   deleteAllergy: (petId: number, allergyId: number, token: string) =>
     api.delete(`/api/pets/${petId}/allergies/${allergyId}`, token),
 
@@ -136,6 +142,8 @@ export const petsApi = {
     api.get<PetVaccination[]>(`/api/pets/${petId}/vaccinations`, token),
   addVaccination: (petId: number, data: Omit<PetVaccination, 'id' | 'pet_id' | 'created_at'>, token: string) =>
     api.post<PetVaccination>(`/api/pets/${petId}/vaccinations`, data, token),
+  updateVaccination: (petId: number, vacId: number, data: Partial<PetVaccination>, token: string) =>
+    api.patch<PetVaccination>(`/api/pets/${petId}/vaccinations/${vacId}`, data, token),
   deleteVaccination: (petId: number, vacId: number, token: string) =>
     api.delete(`/api/pets/${petId}/vaccinations/${vacId}`, token),
 
@@ -143,6 +151,8 @@ export const petsApi = {
     api.get<PetEmergencyContact[]>(`/api/pets/${petId}/emergency-contacts`, token),
   addEmergencyContact: (petId: number, data: Omit<PetEmergencyContact, 'id' | 'pet_id' | 'created_at'>, token: string) =>
     api.post<PetEmergencyContact>(`/api/pets/${petId}/emergency-contacts`, data, token),
+  updateEmergencyContact: (petId: number, contactId: number, data: Partial<PetEmergencyContact>, token: string) =>
+    api.patch<PetEmergencyContact>(`/api/pets/${petId}/emergency-contacts/${contactId}`, data, token),
   deleteEmergencyContact: (petId: number, contactId: number, token: string) =>
     api.delete(`/api/pets/${petId}/emergency-contacts/${contactId}`, token),
 };

--- a/frontend/src/pages/PetDetail.tsx
+++ b/frontend/src/pages/PetDetail.tsx
@@ -456,6 +456,11 @@ function ConditionsTab({ petId, token, conditions, setConditions }: {
   const [name, setName] = useState('');
   const [severity, setSeverity] = useState('');
   const [notes, setNotes] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editSeverity, setEditSeverity] = useState('');
+  const [editNotes, setEditNotes] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const handleAdd = async () => {
     if (!name.trim()) return;
@@ -465,9 +470,24 @@ function ConditionsTab({ petId, token, conditions, setConditions }: {
     setName(''); setSeverity(''); setNotes('');
   };
 
+  const startEdit = (c: PetCondition) => {
+    setEditingId(c.id);
+    setEditName(c.name);
+    setEditSeverity(c.severity || '');
+    setEditNotes(c.notes || '');
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim()) return;
+    const updated = await petsApi.updateCondition(petId, editingId, { name: editName, severity: editSeverity || null, notes: editNotes || null }, token);
+    setConditions(conditions.map(c => c.id === editingId ? updated : c));
+    setEditingId(null);
+  };
+
   const handleDelete = async (id: number) => {
     await petsApi.deleteCondition(petId, id, token);
     setConditions(conditions.filter(c => c.id !== id));
+    setDeletingId(null);
   };
 
   return (
@@ -499,13 +519,43 @@ function ConditionsTab({ petId, token, conditions, setConditions }: {
       ) : (
         <ul className="divide-y">
           {conditions.map(c => (
-            <li key={c.id} className="py-3 flex justify-between items-start">
-              <div>
-                <p className="font-medium">{c.name}</p>
-                {c.severity && <span className="text-sm text-gray-500 capitalize">{c.severity}</span>}
-                {c.notes && <p className="text-sm text-gray-600 mt-1">{c.notes}</p>}
-              </div>
-              <button onClick={() => handleDelete(c.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+            <li key={c.id} className="py-3">
+              {editingId === c.id ? (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                  <input type="text" placeholder="Condition name *" value={editName} onChange={e => setEditName(e.target.value)} className="input" />
+                  <select value={editSeverity} onChange={e => setEditSeverity(e.target.value)} className="input">
+                    <option value="">Severity (optional)</option>
+                    <option value="mild">Mild</option>
+                    <option value="moderate">Moderate</option>
+                    <option value="severe">Severe</option>
+                  </select>
+                  <textarea placeholder="Notes (optional)" value={editNotes} onChange={e => setEditNotes(e.target.value)} className="input" rows={2} />
+                  <div className="flex gap-2">
+                    <button onClick={handleSaveEdit} className="btn-primary text-sm">Save</button>
+                    <button onClick={() => setEditingId(null)} className="btn-secondary text-sm">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{c.name}</p>
+                    {c.severity && <span className="text-sm text-gray-500 capitalize">{c.severity}</span>}
+                    {c.notes && <p className="text-sm text-gray-600 mt-1">{c.notes}</p>}
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={() => startEdit(c)} className="text-primary-600 hover:text-primary-800 text-sm">Edit</button>
+                    {deletingId === c.id ? (
+                      <>
+                        <span className="text-sm text-gray-500">Sure?</span>
+                        <button onClick={() => handleDelete(c.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                      </>
+                    ) : (
+                      <button onClick={() => setDeletingId(c.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                    )}
+                  </div>
+                </div>
+              )}
             </li>
           ))}
         </ul>
@@ -525,6 +575,11 @@ function AllergiesTab({ petId, token, allergies, setAllergies }: {
   const [allergen, setAllergen] = useState('');
   const [reaction, setReaction] = useState('');
   const [severity, setSeverity] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editAllergen, setEditAllergen] = useState('');
+  const [editReaction, setEditReaction] = useState('');
+  const [editSeverity, setEditSeverity] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const handleAdd = async () => {
     if (!allergen.trim()) return;
@@ -534,9 +589,24 @@ function AllergiesTab({ petId, token, allergies, setAllergies }: {
     setAllergen(''); setReaction(''); setSeverity('');
   };
 
+  const startEdit = (a: PetAllergy) => {
+    setEditingId(a.id);
+    setEditAllergen(a.allergen);
+    setEditReaction(a.reaction || '');
+    setEditSeverity(a.severity || '');
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editAllergen.trim()) return;
+    const updated = await petsApi.updateAllergy(petId, editingId, { allergen: editAllergen, reaction: editReaction || null, severity: editSeverity || null }, token);
+    setAllergies(allergies.map(a => a.id === editingId ? updated : a));
+    setEditingId(null);
+  };
+
   const handleDelete = async (id: number) => {
     await petsApi.deleteAllergy(petId, id, token);
     setAllergies(allergies.filter(a => a.id !== id));
+    setDeletingId(null);
   };
 
   return (
@@ -569,13 +639,44 @@ function AllergiesTab({ petId, token, allergies, setAllergies }: {
       ) : (
         <ul className="divide-y">
           {allergies.map(a => (
-            <li key={a.id} className="py-3 flex justify-between items-start">
-              <div>
-                <p className="font-medium">{a.allergen}</p>
-                {a.severity && <span className={`text-sm capitalize ${a.severity === 'life-threatening' ? 'text-red-600 font-semibold' : 'text-gray-500'}`}>{a.severity}</span>}
-                {a.reaction && <p className="text-sm text-gray-600 mt-1">Reaction: {a.reaction}</p>}
-              </div>
-              <button onClick={() => handleDelete(a.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+            <li key={a.id} className="py-3">
+              {editingId === a.id ? (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                  <input type="text" placeholder="Allergen *" value={editAllergen} onChange={e => setEditAllergen(e.target.value)} className="input" />
+                  <input type="text" placeholder="Reaction (optional)" value={editReaction} onChange={e => setEditReaction(e.target.value)} className="input" />
+                  <select value={editSeverity} onChange={e => setEditSeverity(e.target.value)} className="input">
+                    <option value="">Severity (optional)</option>
+                    <option value="mild">Mild</option>
+                    <option value="moderate">Moderate</option>
+                    <option value="severe">Severe</option>
+                    <option value="life-threatening">Life-threatening</option>
+                  </select>
+                  <div className="flex gap-2">
+                    <button onClick={handleSaveEdit} className="btn-primary text-sm">Save</button>
+                    <button onClick={() => setEditingId(null)} className="btn-secondary text-sm">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{a.allergen}</p>
+                    {a.severity && <span className={`text-sm capitalize ${a.severity === 'life-threatening' ? 'text-red-600 font-semibold' : 'text-gray-500'}`}>{a.severity}</span>}
+                    {a.reaction && <p className="text-sm text-gray-600 mt-1">Reaction: {a.reaction}</p>}
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={() => startEdit(a)} className="text-primary-600 hover:text-primary-800 text-sm">Edit</button>
+                    {deletingId === a.id ? (
+                      <>
+                        <span className="text-sm text-gray-500">Sure?</span>
+                        <button onClick={() => handleDelete(a.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                      </>
+                    ) : (
+                      <button onClick={() => setDeletingId(a.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                    )}
+                  </div>
+                </div>
+              )}
             </li>
           ))}
         </ul>
@@ -595,6 +696,11 @@ function MedicationsTab({ petId, token, medications, setMedications }: {
   const [name, setName] = useState('');
   const [dosage, setDosage] = useState('');
   const [frequency, setFrequency] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editDosage, setEditDosage] = useState('');
+  const [editFrequency, setEditFrequency] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const handleAdd = async () => {
     if (!name.trim()) return;
@@ -607,6 +713,20 @@ function MedicationsTab({ petId, token, medications, setMedications }: {
     setName(''); setDosage(''); setFrequency('');
   };
 
+  const startEdit = (m: PetMedication) => {
+    setEditingId(m.id);
+    setEditName(m.name);
+    setEditDosage(m.dosage || '');
+    setEditFrequency(m.frequency || '');
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim()) return;
+    const updated = await petsApi.updateMedication(petId, editingId, { name: editName, dosage: editDosage || null, frequency: editFrequency || null }, token);
+    setMedications(medications.map(m => m.id === editingId ? updated : m));
+    setEditingId(null);
+  };
+
   const handleToggleActive = async (med: PetMedication) => {
     const updated = await petsApi.updateMedication(petId, med.id, { is_active: !med.is_active }, token);
     setMedications(medications.map(m => m.id === med.id ? updated : m));
@@ -615,10 +735,50 @@ function MedicationsTab({ petId, token, medications, setMedications }: {
   const handleDelete = async (id: number) => {
     await petsApi.deleteMedication(petId, id, token);
     setMedications(medications.filter(m => m.id !== id));
+    setDeletingId(null);
   };
 
   const active = medications.filter(m => m.is_active);
   const inactive = medications.filter(m => !m.is_active);
+
+  const renderMedRow = (m: PetMedication, isInactive?: boolean) => (
+    <li key={m.id} className="p-3">
+      {editingId === m.id ? (
+        <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+          <input type="text" placeholder="Medication name *" value={editName} onChange={e => setEditName(e.target.value)} className="input" />
+          <input type="text" placeholder="Dosage (e.g., 10mg)" value={editDosage} onChange={e => setEditDosage(e.target.value)} className="input" />
+          <input type="text" placeholder="Frequency (e.g., twice daily)" value={editFrequency} onChange={e => setEditFrequency(e.target.value)} className="input" />
+          <div className="flex gap-2">
+            <button onClick={handleSaveEdit} className="btn-primary text-sm">Save</button>
+            <button onClick={() => setEditingId(null)} className="btn-secondary text-sm">Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex justify-between items-start">
+          <div>
+            <p className={`font-medium ${isInactive ? 'line-through' : ''}`}>{m.name}</p>
+            {m.dosage && <span className="text-sm text-gray-500">{m.dosage}</span>}
+            {m.frequency && <span className="text-sm text-gray-500"> - {m.frequency}</span>}
+          </div>
+          <div className="flex gap-2">
+            <button onClick={() => startEdit(m)} className="text-primary-600 hover:text-primary-800 text-sm">Edit</button>
+            <button onClick={() => handleToggleActive(m)} className={`text-sm ${isInactive ? 'text-primary-600 hover:text-primary-800' : 'text-gray-600 hover:text-gray-800'}`}>
+              {isInactive ? 'Reactivate' : 'Discontinue'}
+            </button>
+            {deletingId === m.id ? (
+              <>
+                <span className="text-sm text-gray-500">Sure?</span>
+                <button onClick={() => handleDelete(m.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
+                <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+              </>
+            ) : (
+              <button onClick={() => setDeletingId(m.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+            )}
+          </div>
+        </div>
+      )}
+    </li>
+  );
 
   return (
     <div>
@@ -643,19 +803,7 @@ function MedicationsTab({ petId, token, medications, setMedications }: {
         <div className="mb-6">
           <h4 className="text-sm font-medium text-gray-500 mb-2">Active Medications</h4>
           <ul className="divide-y border rounded-lg">
-            {active.map(m => (
-              <li key={m.id} className="p-3 flex justify-between items-start">
-                <div>
-                  <p className="font-medium">{m.name}</p>
-                  {m.dosage && <span className="text-sm text-gray-500">{m.dosage}</span>}
-                  {m.frequency && <span className="text-sm text-gray-500"> - {m.frequency}</span>}
-                </div>
-                <div className="flex gap-2">
-                  <button onClick={() => handleToggleActive(m)} className="text-gray-600 hover:text-gray-800 text-sm">Discontinue</button>
-                  <button onClick={() => handleDelete(m.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
-                </div>
-              </li>
-            ))}
+            {active.map(m => renderMedRow(m))}
           </ul>
         </div>
       )}
@@ -664,18 +812,7 @@ function MedicationsTab({ petId, token, medications, setMedications }: {
         <div>
           <h4 className="text-sm font-medium text-gray-500 mb-2">Past Medications</h4>
           <ul className="divide-y border rounded-lg opacity-60">
-            {inactive.map(m => (
-              <li key={m.id} className="p-3 flex justify-between items-start">
-                <div>
-                  <p className="font-medium line-through">{m.name}</p>
-                  {m.dosage && <span className="text-sm text-gray-500">{m.dosage}</span>}
-                </div>
-                <div className="flex gap-2">
-                  <button onClick={() => handleToggleActive(m)} className="text-primary-600 hover:text-primary-800 text-sm">Reactivate</button>
-                  <button onClick={() => handleDelete(m.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
-                </div>
-              </li>
-            ))}
+            {inactive.map(m => renderMedRow(m, true))}
           </ul>
         </div>
       )}
@@ -698,6 +835,11 @@ function VaccinationsTab({ petId, token, vaccinations, setVaccinations }: {
   const [name, setName] = useState('');
   const [adminDate, setAdminDate] = useState('');
   const [expDate, setExpDate] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editAdminDate, setEditAdminDate] = useState('');
+  const [editExpDate, setEditExpDate] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const handleAdd = async () => {
     if (!name.trim() || !adminDate) return;
@@ -711,9 +853,26 @@ function VaccinationsTab({ petId, token, vaccinations, setVaccinations }: {
     setName(''); setAdminDate(''); setExpDate('');
   };
 
+  const toDateInput = (d: string | null) => d ? d.split('T')[0] : '';
+
+  const startEdit = (v: PetVaccination) => {
+    setEditingId(v.id);
+    setEditName(v.name);
+    setEditAdminDate(toDateInput(v.administered_date));
+    setEditExpDate(toDateInput(v.expiration_date));
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim() || !editAdminDate) return;
+    const updated = await petsApi.updateVaccination(petId, editingId, { name: editName, administered_date: editAdminDate, expiration_date: editExpDate || null }, token);
+    setVaccinations(vaccinations.map(v => v.id === editingId ? updated : v));
+    setEditingId(null);
+  };
+
   const handleDelete = async (id: number) => {
     await petsApi.deleteVaccination(petId, id, token);
     setVaccinations(vaccinations.filter(v => v.id !== id));
+    setDeletingId(null);
   };
 
   const isExpired = (expDate: string | null) => {
@@ -753,19 +912,52 @@ function VaccinationsTab({ petId, token, vaccinations, setVaccinations }: {
       ) : (
         <ul className="divide-y">
           {vaccinations.map(v => (
-            <li key={v.id} className="py-3 flex justify-between items-start">
-              <div>
-                <p className="font-medium">{v.name}</p>
-                <p className="text-sm text-gray-500">
-                  Administered: {new Date(v.administered_date.split('T')[0] + 'T00:00:00').toLocaleDateString()}
-                </p>
-                {v.expiration_date && (
-                  <p className={`text-sm ${isExpired(v.expiration_date) ? 'text-red-600' : 'text-gray-500'}`}>
-                    {isExpired(v.expiration_date) ? 'Expired' : 'Expires'}: {new Date(v.expiration_date.split('T')[0] + 'T00:00:00').toLocaleDateString()}
-                  </p>
-                )}
-              </div>
-              <button onClick={() => handleDelete(v.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+            <li key={v.id} className="py-3">
+              {editingId === v.id ? (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                  <input type="text" placeholder="Vaccination name *" value={editName} onChange={e => setEditName(e.target.value)} className="input" />
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="text-sm text-gray-600">Date administered *</label>
+                      <input type="date" value={editAdminDate} onChange={e => setEditAdminDate(e.target.value)} className="input" />
+                    </div>
+                    <div>
+                      <label className="text-sm text-gray-600">Expiration date</label>
+                      <input type="date" value={editExpDate} onChange={e => setEditExpDate(e.target.value)} className="input" />
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={handleSaveEdit} className="btn-primary text-sm">Save</button>
+                    <button onClick={() => setEditingId(null)} className="btn-secondary text-sm">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{v.name}</p>
+                    <p className="text-sm text-gray-500">
+                      Administered: {new Date(v.administered_date.split('T')[0] + 'T00:00:00').toLocaleDateString()}
+                    </p>
+                    {v.expiration_date && (
+                      <p className={`text-sm ${isExpired(v.expiration_date) ? 'text-red-600' : 'text-gray-500'}`}>
+                        {isExpired(v.expiration_date) ? 'Expired' : 'Expires'}: {new Date(v.expiration_date.split('T')[0] + 'T00:00:00').toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={() => startEdit(v)} className="text-primary-600 hover:text-primary-800 text-sm">Edit</button>
+                    {deletingId === v.id ? (
+                      <>
+                        <span className="text-sm text-gray-500">Sure?</span>
+                        <button onClick={() => handleDelete(v.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                      </>
+                    ) : (
+                      <button onClick={() => setDeletingId(v.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                    )}
+                  </div>
+                </div>
+              )}
             </li>
           ))}
         </ul>
@@ -785,6 +977,11 @@ function VetsTab({ petId, token, vets, setVets }: {
   const [clinicName, setClinicName] = useState('');
   const [vetName, setVetName] = useState('');
   const [phone, setPhone] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editClinicName, setEditClinicName] = useState('');
+  const [editVetName, setEditVetName] = useState('');
+  const [editPhone, setEditPhone] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const handleAdd = async () => {
     if (!clinicName.trim()) return;
@@ -797,14 +994,28 @@ function VetsTab({ petId, token, vets, setVets }: {
     setClinicName(''); setVetName(''); setPhone('');
   };
 
+  const startEdit = (v: PetVet) => {
+    setEditingId(v.id);
+    setEditClinicName(v.clinic_name);
+    setEditVetName(v.vet_name || '');
+    setEditPhone(v.phone || '');
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editClinicName.trim()) return;
+    const updated = await petsApi.updateVet(petId, editingId, { clinic_name: editClinicName, vet_name: editVetName || null, phone: editPhone || null }, token);
+    setVets(vets.map(v => v.id === editingId ? updated : v));
+    setEditingId(null);
+  };
+
   const handleDelete = async (id: number) => {
     await petsApi.deleteVet(petId, id, token);
     setVets(vets.filter(v => v.id !== id));
+    setDeletingId(null);
   };
 
   const handleSetPrimary = async (vetId: number) => {
     await petsApi.setPrimaryVet(petId, vetId, token);
-    // Update local state: unset all as primary, then set the selected one
     setVets(vets.map(v => ({ ...v, is_primary: v.id === vetId })));
   };
 
@@ -832,23 +1043,41 @@ function VetsTab({ petId, token, vets, setVets }: {
       ) : (
         <ul className="divide-y">
           {vets.map(v => (
-            <li key={v.id} className="py-3 flex justify-between items-start">
-              <div>
-                <p className="font-medium">{v.clinic_name} {v.is_primary && <span className="text-xs bg-primary-100 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
-                {v.vet_name && <p className="text-sm text-gray-600">Dr. {v.vet_name}</p>}
-                {v.phone && <p className="text-sm text-gray-500">{v.phone}</p>}
-              </div>
-              <div className="flex gap-2">
-                {!v.is_primary && (
-                  <button
-                    onClick={() => handleSetPrimary(v.id)}
-                    className="text-primary-600 hover:text-primary-800 text-sm"
-                  >
-                    Set as Primary
-                  </button>
-                )}
-                <button onClick={() => handleDelete(v.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
-              </div>
+            <li key={v.id} className="py-3">
+              {editingId === v.id ? (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                  <input type="text" placeholder="Clinic name *" value={editClinicName} onChange={e => setEditClinicName(e.target.value)} className="input" />
+                  <input type="text" placeholder="Vet name" value={editVetName} onChange={e => setEditVetName(e.target.value)} className="input" />
+                  <input type="tel" placeholder="Phone number" value={editPhone} onChange={e => setEditPhone(e.target.value)} className="input" />
+                  <div className="flex gap-2">
+                    <button onClick={handleSaveEdit} className="btn-primary text-sm">Save</button>
+                    <button onClick={() => setEditingId(null)} className="btn-secondary text-sm">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{v.clinic_name} {v.is_primary && <span className="text-xs bg-primary-100 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
+                    {v.vet_name && <p className="text-sm text-gray-600">Dr. {v.vet_name}</p>}
+                    {v.phone && <p className="text-sm text-gray-500">{v.phone}</p>}
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={() => startEdit(v)} className="text-primary-600 hover:text-primary-800 text-sm">Edit</button>
+                    {!v.is_primary && (
+                      <button onClick={() => handleSetPrimary(v.id)} className="text-primary-600 hover:text-primary-800 text-sm">Set as Primary</button>
+                    )}
+                    {deletingId === v.id ? (
+                      <>
+                        <span className="text-sm text-gray-500">Sure?</span>
+                        <button onClick={() => handleDelete(v.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                      </>
+                    ) : (
+                      <button onClick={() => setDeletingId(v.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                    )}
+                  </div>
+                </div>
+              )}
             </li>
           ))}
         </ul>
@@ -868,6 +1097,11 @@ function ContactsTab({ petId, token, contacts, setContacts }: {
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [relationship, setRelationship] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editPhone, setEditPhone] = useState('');
+  const [editRelationship, setEditRelationship] = useState('');
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const handleAdd = async () => {
     if (!name.trim() || !phone.trim()) return;
@@ -879,9 +1113,24 @@ function ContactsTab({ petId, token, contacts, setContacts }: {
     setName(''); setPhone(''); setRelationship('');
   };
 
+  const startEdit = (c: PetEmergencyContact) => {
+    setEditingId(c.id);
+    setEditName(c.name);
+    setEditPhone(c.phone);
+    setEditRelationship(c.relationship || '');
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !editName.trim() || !editPhone.trim()) return;
+    const updated = await petsApi.updateEmergencyContact(petId, editingId, { name: editName, phone: editPhone, relationship: editRelationship || null }, token);
+    setContacts(contacts.map(c => c.id === editingId ? updated : c));
+    setEditingId(null);
+  };
+
   const handleDelete = async (id: number) => {
     await petsApi.deleteEmergencyContact(petId, id, token);
     setContacts(contacts.filter(c => c.id !== id));
+    setDeletingId(null);
   };
 
   return (
@@ -908,13 +1157,38 @@ function ContactsTab({ petId, token, contacts, setContacts }: {
       ) : (
         <ul className="divide-y">
           {contacts.map(c => (
-            <li key={c.id} className="py-3 flex justify-between items-start">
-              <div>
-                <p className="font-medium">{c.name} {c.is_primary && <span className="text-xs bg-primary-100 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
-                {c.relationship && <p className="text-sm text-gray-600">{c.relationship}</p>}
-                <p className="text-sm text-gray-500">{c.phone}</p>
-              </div>
-              <button onClick={() => handleDelete(c.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+            <li key={c.id} className="py-3">
+              {editingId === c.id ? (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                  <input type="text" placeholder="Name *" value={editName} onChange={e => setEditName(e.target.value)} className="input" />
+                  <input type="tel" placeholder="Phone *" value={editPhone} onChange={e => setEditPhone(e.target.value)} className="input" />
+                  <input type="text" placeholder="Relationship (e.g., spouse, neighbor)" value={editRelationship} onChange={e => setEditRelationship(e.target.value)} className="input" />
+                  <div className="flex gap-2">
+                    <button onClick={handleSaveEdit} className="btn-primary text-sm">Save</button>
+                    <button onClick={() => setEditingId(null)} className="btn-secondary text-sm">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{c.name} {c.is_primary && <span className="text-xs bg-primary-100 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
+                    {c.relationship && <p className="text-sm text-gray-600">{c.relationship}</p>}
+                    <p className="text-sm text-gray-500">{c.phone}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={() => startEdit(c)} className="text-primary-600 hover:text-primary-800 text-sm">Edit</button>
+                    {deletingId === c.id ? (
+                      <>
+                        <span className="text-sm text-gray-500">Sure?</span>
+                        <button onClick={() => handleDelete(c.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                      </>
+                    ) : (
+                      <button onClick={() => setDeletingId(c.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                    )}
+                  </div>
+                </div>
+              )}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- Adds inline editing (expand/collapse) to all 6 pet profile tabs: Conditions, Allergies, Medications, Vaccinations, Veterinarians, Emergency Contacts
- Adds delete confirmation ("Sure? Yes/No") to prevent accidental deletes on all tabs
- Backend: adds 3 missing model update functions (`updatePetAllergy`, `updatePetVaccination`, `updatePetEmergencyContact`) and 5 missing PATCH endpoints
- Frontend: adds 5 update API methods and inline edit forms to each tab component

## Test plan
- [ ] For each tab: click Edit → verify inline form appears with current values pre-filled
- [ ] Modify fields → Save → verify record is updated
- [ ] Edit → Cancel → verify changes are discarded
- [ ] Click Delete → verify "Sure? Yes/No" confirmation appears
- [ ] Confirm delete → verify record is removed
- [ ] Cancel delete → verify record stays
- [ ] Add new records still works as before
- [ ] Check History tab shows edit audit entries

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)