### PR TITLE
feat: enable AI extraction for image uploads (photos of documents)

### DIFF
--- a/backend/src/routes/document-import.ts
+++ b/backend/src/routes/document-import.ts
@@ -112,90 +112,168 @@ router.post('/:petId/documents/upload', authenticate, requireFeature('upload'), 
 
     const mediaType = getMediaTypeFromMime(fileMimeType);
 
+    // Extract EXIF metadata for images (date taken, dimensions)
+    let imageMeta: { dateTaken: string | null; width: number | null; height: number | null } | null = null;
     if (mediaType === 'image') {
-      // Images: extract EXIF metadata, set status to pending_review, skip AI
-      const imageMeta = await extractImageMetadata(fileBuffer);
-      await updateDocumentUploadStatus(documentUpload.id, 'pending_review');
-      const updatedUpload = await getDocumentUploadById(documentUpload.id);
+      imageMeta = await extractImageMetadata(fileBuffer);
+    }
 
-      res.status(201).json({
-        upload: updatedUpload,
-        media_type: 'image',
+    // Process through AI classification + extraction for all document types
+    const result = await processDocumentUpload(documentUpload.id);
+
+    if (result.error) {
+      res.status(500).json({
+        error: result.error,
+        upload: result.upload,
+        media_type: mediaType,
+        detected_type: result.classification?.detectedType || null,
+        confidence: result.classification?.confidence || 0,
+        explanation: result.classification?.explanation || result.error,
+        ...(imageMeta && {
+          exif_date_taken: imageMeta.dateTaken,
+          image_width: imageMeta.width,
+          image_height: imageMeta.height,
+        }),
+      });
+      return;
+    }
+
+    const extractedItems = result.items?.map((item) => ({
+      id: item.id,
+      record_type: item.record_type,
+      data: item.extracted_data,
+      confidence: item.confidence_score,
+      status: item.status,
+    })) || [];
+
+    const byCategory: Record<string, number> = {
+      medications: 0,
+      vaccinations: 0,
+      conditions: 0,
+      allergies: 0,
+      vets: 0,
+      emergency_contacts: 0,
+    };
+
+    for (const item of extractedItems) {
+      switch (item.record_type) {
+        case 'medication':
+          byCategory.medications++;
+          break;
+        case 'vaccination':
+          byCategory.vaccinations++;
+          break;
+        case 'condition':
+          byCategory.conditions++;
+          break;
+        case 'allergy':
+          byCategory.allergies++;
+          break;
+        case 'vet':
+          byCategory.vets++;
+          break;
+        case 'emergency_contact':
+          byCategory.emergency_contacts++;
+          break;
+      }
+    }
+
+    res.status(201).json({
+      upload: result.upload,
+      media_type: mediaType,
+      upload_id: result.upload.id,
+      detected_type: result.classification?.detectedType || 'other',
+      confidence: result.classification?.confidence || 0,
+      explanation: result.classification?.explanation || '',
+      extracted_items: extractedItems,
+      summary: generateExtractedItemsSummary(byCategory),
+      extraction_id: result.extraction?.id,
+      ...(imageMeta && {
         exif_date_taken: imageMeta.dateTaken,
         image_width: imageMeta.width,
         image_height: imageMeta.height,
-      });
-    } else {
-      // PDFs: existing processDocumentUpload flow
-      const result = await processDocumentUpload(documentUpload.id);
-
-      if (result.error) {
-        res.status(500).json({
-          error: result.error,
-          upload: result.upload,
-          media_type: 'pdf',
-          detected_type: result.classification?.detectedType || null,
-          confidence: result.classification?.confidence || 0,
-          explanation: result.classification?.explanation || result.error,
-        });
-        return;
-      }
-
-      const extractedItems = result.items?.map((item) => ({
-        id: item.id,
-        record_type: item.record_type,
-        data: item.extracted_data,
-        confidence: item.confidence_score,
-        status: item.status,
-      })) || [];
-
-      const byCategory: Record<string, number> = {
-        medications: 0,
-        vaccinations: 0,
-        conditions: 0,
-        allergies: 0,
-        vets: 0,
-        emergency_contacts: 0,
-      };
-
-      for (const item of extractedItems) {
-        switch (item.record_type) {
-          case 'medication':
-            byCategory.medications++;
-            break;
-          case 'vaccination':
-            byCategory.vaccinations++;
-            break;
-          case 'condition':
-            byCategory.conditions++;
-            break;
-          case 'allergy':
-            byCategory.allergies++;
-            break;
-          case 'vet':
-            byCategory.vets++;
-            break;
-          case 'emergency_contact':
-            byCategory.emergency_contacts++;
-            break;
-        }
-      }
-
-      res.status(201).json({
-        upload: result.upload,
-        media_type: 'pdf',
-        upload_id: result.upload.id,
-        detected_type: result.classification?.detectedType || 'other',
-        confidence: result.classification?.confidence || 0,
-        explanation: result.classification?.explanation || '',
-        extracted_items: extractedItems,
-        summary: generateExtractedItemsSummary(byCategory),
-        extraction_id: result.extraction?.id,
-      });
-    }
+      }),
+    });
   } catch (error: any) {
     console.error('Document upload error:', error);
     res.status(500).json({ error: error.message || 'Upload failed' });
+  }
+});
+
+// POST /api/pets/:petId/documents/uploads/:id/process - Trigger AI processing for an existing upload
+router.post('/:petId/documents/uploads/:id/process', authenticate, requireFeature('upload'), claudeRateLimit, async (req: AuthRequest, res: Response) => {
+  try {
+    const petId = parseInt(req.params.petId);
+    const uploadId = parseInt(req.params.id);
+
+    if (!await verifyPetEditAccess(petId, req.userId!, res)) {
+      return;
+    }
+
+    const upload = await getDocumentUploadById(uploadId);
+    if (!upload || upload.pet_id !== petId) {
+      res.status(404).json({ error: 'Upload not found' });
+      return;
+    }
+
+    // Only allow processing uploads that haven't been successfully processed yet
+    const extraction = await getDocumentExtractionWithItems(uploadId);
+    if (extraction && extraction.items.length > 0) {
+      res.status(400).json({ error: 'This upload has already been processed' });
+      return;
+    }
+
+    if (!config.claude.apiKey) {
+      res.status(500).json({ error: 'AI processing is not configured' });
+      return;
+    }
+
+    const result = await processDocumentUpload(uploadId);
+
+    if (result.error) {
+      res.status(500).json({
+        error: result.error,
+        upload: result.upload,
+      });
+      return;
+    }
+
+    const extractedItems = result.items?.map((item) => ({
+      id: item.id,
+      record_type: item.record_type,
+      data: item.extracted_data,
+      confidence: item.confidence_score,
+      status: item.status,
+    })) || [];
+
+    const byCategory: Record<string, number> = {
+      medications: 0, vaccinations: 0, conditions: 0,
+      allergies: 0, vets: 0, emergency_contacts: 0,
+    };
+
+    for (const item of extractedItems) {
+      switch (item.record_type) {
+        case 'medication': byCategory.medications++; break;
+        case 'vaccination': byCategory.vaccinations++; break;
+        case 'condition': byCategory.conditions++; break;
+        case 'allergy': byCategory.allergies++; break;
+        case 'vet': byCategory.vets++; break;
+        case 'emergency_contact': byCategory.emergency_contacts++; break;
+      }
+    }
+
+    res.json({
+      upload: result.upload,
+      detected_type: result.classification?.detectedType || 'other',
+      confidence: result.classification?.confidence || 0,
+      explanation: result.classification?.explanation || '',
+      extracted_items: extractedItems,
+      summary: generateExtractedItemsSummary(byCategory),
+      extraction_id: result.extraction?.id,
+    });
+  } catch (error: any) {
+    console.error('Document process error:', error);
+    res.status(500).json({ error: error.message || 'Processing failed' });
   }
 });
 

--- a/backend/src/services/document-classifier.ts
+++ b/backend/src/services/document-classifier.ts
@@ -91,6 +91,15 @@ For each extracted item, provide a confidence score from 0.0 to 1.0:
 - 0.5-0.7: Information is inferred or partially legible
 - Below 0.5: Information is unclear or guessed
 
+IMPORTANT — Receipts and invoices:
+When processing veterinary invoices, receipts, or billing statements:
+- Distinguish between medications ADMINISTERED IN-CLINIC during the visit (e.g., anesthesia drugs, surgical injections, IV fluids given during a procedure) and PRESCRIBED/TAKE-HOME medications.
+- For in-clinic administered medications: set is_active to false and add a note like "Administered in-clinic during [procedure name]" so the owner knows this is not a current prescription.
+- For take-home/prescribed medications (e.g., oral tablets, refills): set is_active to true.
+- Common in-clinic-only medications include: anesthesia agents (propofol, alfaxan, ketamine, isoflurane), surgical analgesics given IV/IM (methadone, fentanyl, hydromorphone, torbugesic/butorphanol), pre-anesthetic sedatives (acepromazine, dexmedetomidine), surgical antibiotics given IV (cefazolin), muscle relaxants, and IV fluids (Lactated Ringers, saline). These are almost never sent home.
+- Surgical procedures (e.g., "Exploratory Laparotomy", "Mass Removal", "Dental Cleaning") should be extracted as condition records with the procedure name, the visit date as diagnosed_date, and a note describing it as a procedure.
+- Extract each unique vet name as a separate vet record tied to the same clinic.
+
 Respond with a JSON object:
 {
   "pet_name": "Name of pet if visible",
@@ -137,11 +146,11 @@ Field formats:
 - Dates should be in YYYY-MM-DD format when possible, or null if not available
 - severity should be: "mild", "moderate", or "severe" for conditions
 - severity for allergies: "mild", "moderate", "severe", or "life-threatening"
-- is_active for medications should be true for current prescriptions
+- is_active for medications should be true for current prescriptions, false for medications administered in-clinic during a procedure
 - show_on_card indicates whether this item should appear as an alert on the pet's emergency card:
   - For allergies: true if severity is "life-threatening" or "severe"
-  - For conditions: true if the condition is clinically significant and would affect emergency treatment (e.g., epilepsy, heart disease, diabetes). False for minor/resolved conditions.
-  - For medications: true if the medication has critical drug interactions or the pet must not miss doses (e.g., insulin, anti-seizure, heart medication). False for routine supplements or topicals.
+  - For conditions: true if the condition is clinically significant and would affect emergency treatment (e.g., epilepsy, heart disease, diabetes). False for minor/resolved conditions and past surgical procedures.
+  - For medications: true if the medication has critical drug interactions or the pet must not miss doses (e.g., insulin, anti-seizure, heart medication). False for routine supplements, topicals, or in-clinic administered medications.
   - For vaccinations: true if the vaccination is expired or critically overdue (e.g., rabies). False for routine up-to-date vaccinations.
 
 Only extract information that is actually present in the document.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -837,6 +837,10 @@ export const documentsApi = {
   renameUpload: (petId: number, uploadId: number, newFilename: string, token: string) =>
     api.patch<DocumentUpload>(`/api/pets/${petId}/documents/uploads/${uploadId}/rename`, { filename: newFilename }, token),
 
+  // Trigger AI processing for an existing upload (e.g., scan image for records)
+  processUpload: (petId: number, uploadId: number, token: string) =>
+    api.post<any>(`/api/pets/${petId}/documents/uploads/${uploadId}/process`, {}, token),
+
   // Save image metadata (tag, description, date, body area)
   saveImageMetadata: (
     petId: number,

--- a/frontend/src/components/document-import/DocumentImportSection.tsx
+++ b/frontend/src/components/document-import/DocumentImportSection.tsx
@@ -45,8 +45,13 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
         setCurrentUpload(upload);
         setActiveHighlightItemId(highlightItemId ?? null);
         if (upload.file_type === 'image') {
-          setExifDateTaken(null);
-          setViewState('image_review');
+          const hasExtractionItems = (upload.pending_items || 0) + (upload.approved_items || 0) + (upload.rejected_items || 0) > 0;
+          if (hasExtractionItems) {
+            setViewState('review');
+          } else {
+            setExifDateTaken(null);
+            setViewState('image_review');
+          }
         } else {
           setViewState('review');
         }
@@ -73,15 +78,17 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
 
   const handleUploadComplete = async (result: any) => {
     setError(null);
+    setCurrentUpload(result.upload);
+    setExifDateTaken(result.exif_date_taken || null);
 
-    if (result.media_type === 'image') {
-      // Image: go to image review form
-      setCurrentUpload(result.upload);
-      setExifDateTaken(result.exif_date_taken || null);
+    // If AI found extracted items, go to extraction review regardless of media type
+    if (result.extracted_items && result.extracted_items.length > 0) {
+      setViewState('review');
+    } else if (result.media_type === 'image') {
+      // Image with no extracted items — go to image metadata form
       setViewState('image_review');
     } else {
-      // PDF: backend already processed, go straight to extraction review
-      setCurrentUpload(result.upload);
+      // PDF with no items — still show extraction review (shows "no data found" message)
       setViewState('review');
     }
   };
@@ -101,12 +108,20 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
   };
 
   const handleUploadSelect = (upload: DocumentUpload) => {
-    if (upload.file_type === 'image' && (upload.status === 'pending_review' || upload.status === 'completed')) {
-      setCurrentUpload(upload);
-      setExifDateTaken(null);
-      setViewState('image_review');
-    } else if (upload.status === 'completed' || upload.status === 'pending_review') {
-      setCurrentUpload(upload);
+    if (upload.status !== 'pending_review' && upload.status !== 'completed') return;
+
+    setCurrentUpload(upload);
+
+    if (upload.file_type === 'image') {
+      // If image has extraction items, go to extraction review; otherwise metadata form
+      const hasExtractionItems = (upload.pending_items || 0) + (upload.approved_items || 0) + (upload.rejected_items || 0) > 0;
+      if (hasExtractionItems) {
+        setViewState('review');
+      } else {
+        setExifDateTaken(null);
+        setViewState('image_review');
+      }
+    } else {
       setViewState('review');
     }
   };
@@ -124,6 +139,9 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
 
   // Image review state
   if (viewState === 'image_review' && currentUpload) {
+    // Show "Scan for Records" button only for images that haven't been processed yet
+    const hasExtractionItems = (currentUpload.pending_items || 0) + (currentUpload.approved_items || 0) + (currentUpload.rejected_items || 0) > 0;
+
     return (
       <ImageReviewForm
         petId={petId}
@@ -136,6 +154,11 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
           onImportComplete?.();
         }}
         onCancel={handleBackToUploads}
+        onScanComplete={hasExtractionItems ? undefined : (result) => {
+          // Scan found items — switch to extraction review
+          setCurrentUpload(result.upload);
+          setViewState('review');
+        }}
       />
     );
   }

--- a/frontend/src/components/document-import/ImageReviewForm.tsx
+++ b/frontend/src/components/document-import/ImageReviewForm.tsx
@@ -21,9 +21,10 @@ interface ImageReviewFormProps {
   exifDateTaken?: string | null;
   onSave: () => void;
   onCancel: () => void;
+  onScanComplete?: (result: any) => void;
 }
 
-export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel }: ImageReviewFormProps) {
+export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel, onScanComplete }: ImageReviewFormProps) {
   const { token } = useAuth();
   const [tag, setTag] = useState(upload.user_tag || '');
   const [description, setDescription] = useState(upload.user_description || '');
@@ -39,7 +40,28 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
   });
   const [bodyArea, setBodyArea] = useState(upload.body_area || '');
   const [isSaving, setIsSaving] = useState(false);
+  const [isScanning, setIsScanning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const handleScan = async () => {
+    if (!token) return;
+
+    setIsScanning(true);
+    setError(null);
+
+    try {
+      const result = await documentsApi.processUpload(petId, upload.id, token);
+      if (result.extracted_items && result.extracted_items.length > 0) {
+        onScanComplete?.(result);
+      } else {
+        setError('No health records found in this image. You can still save it with a tag.');
+      }
+    } catch (err: any) {
+      setError(err.message || 'Scan failed');
+    } finally {
+      setIsScanning(false);
+    }
+  };
 
   const imageUrl = `${API_URL}/api/pets/${petId}/documents/uploads/${upload.id}/file`;
 
@@ -97,6 +119,37 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
       </div>
 
       <p className="text-sm text-gray-500 text-center">{upload.original_filename}</p>
+
+      {/* Scan for records button — shown for images that haven't been processed */}
+      {onScanComplete && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+          <p className="text-sm text-amber-800 mb-3">
+            Is this a photo of a veterinary document, receipt, or record? Scan it to automatically extract medications, conditions, and other health data.
+          </p>
+          <button
+            onClick={handleScan}
+            disabled={isScanning}
+            className="w-full bg-amber-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {isScanning ? (
+              <>
+                <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Scanning...
+              </>
+            ) : (
+              <>
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                </svg>
+                Scan for Health Records
+              </>
+            )}
+          </button>
+        </div>
+      )}
 
       {/* Form fields */}
       <div className="space-y-4">


### PR DESCRIPTION
## Summary
- **Image uploads now go through Claude Vision AI** — photos of vet invoices, receipts, medication labels, and records are automatically scanned for medications, conditions, vet info, and more
- **Smart receipt handling** — the extraction prompt now distinguishes in-clinic administered medications (anesthesia, surgical injections, IV fluids → `is_active: false`) from take-home prescriptions (`is_active: true`), and extracts surgical procedures as condition records
- **New `/process` endpoint** — existing unprocessed image uploads can be scanned on demand via `POST /documents/uploads/:id/process`
- **"Scan for Health Records" button** — shown on the image review form for legacy images uploaded before this change, letting users trigger AI extraction retroactively
- **Frontend routing updated** — images with extracted items route to the extraction review UI (same as PDFs); images with no items route to the metadata tagging form as before

## Test plan
- [ ] Upload a photo of a vet invoice/receipt and verify AI extracts medications, conditions, and vet info
- [ ] Verify in-clinic medications (anesthesia drugs) are marked `is_active: false` with appropriate notes
- [ ] Verify take-home medications are marked `is_active: true`
- [ ] Verify `is_active` can be toggled by the user during the review process
- [ ] Upload a regular pet photo and verify it falls through to the metadata tagging form
- [ ] Open an existing unprocessed image upload and verify "Scan for Health Records" button appears and works
- [ ] Verify PDF upload flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)