### PR TITLE
fix: Redis-backed rate limiting with proper IP resolution

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "nanoid": "^5.0.4",
         "nodemailer": "^8.0.0",
         "pg": "^8.11.3",
+        "rate-limit-redis": "^4.3.1",
         "sharp": "^0.33.5",
         "stripe": "^20.3.0",
         "zod": "^3.22.4"
@@ -4088,6 +4089,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
       "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -5465,6 +5467,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
       }
     },
     "node_modules/raw-body": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,6 +63,7 @@
     "nanoid": "^5.0.4",
     "nodemailer": "^8.0.0",
     "pg": "^8.11.3",
+    "rate-limit-redis": "^4.3.1",
     "sharp": "^0.33.5",
     "stripe": "^20.3.0",
     "zod": "^3.22.4"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import path from 'path';
 import { config } from './config/index.js';
+import { createRedisStore, getClientIp } from './middleware/rate-limit-store.js';
 import authRoutes from './routes/auth.js';
 import petRoutes from './routes/pets.js';
 import publicRoutes from './routes/public.js';
@@ -34,10 +35,12 @@ app.use(cors({
   credentials: true,
 }));
 
-// Rate limiting
+// Rate limiting — Redis-backed, keyed by real client IP
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: config.isProduction ? 500 : 10000, // higher limit in dev
+  max: config.isProduction ? 500 : 10000,
+  keyGenerator: getClientIp,
+  store: createRedisStore('global'),
   message: { error: 'Too many requests, please try again later.' },
 });
 app.use(limiter);

--- a/backend/src/middleware/rate-limit-claude.ts
+++ b/backend/src/middleware/rate-limit-claude.ts
@@ -1,5 +1,6 @@
 import rateLimit from 'express-rate-limit';
 import { AuthRequest } from './auth.js';
+import { createRedisStore, getClientIp } from './rate-limit-store.js';
 
 // Rate limiter for Claude API calls (PDF processing)
 // 10 requests per minute per user
@@ -7,9 +8,9 @@ export const claudeRateLimit = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 10, // 10 requests per window
   keyGenerator: (req: AuthRequest) => {
-    // Use user ID for rate limiting (requires authentication)
-    return `claude:${req.userId || req.ip}`;
+    return String(req.userId || getClientIp(req));
   },
+  store: createRedisStore('claude'),
   message: {
     error: 'Too many PDF processing requests. Please wait a moment before trying again.',
     retryAfter: 60,
@@ -30,8 +31,9 @@ export const pdfUploadRateLimit = rateLimit({
   windowMs: 60 * 1000,
   max: 20,
   keyGenerator: (req: AuthRequest) => {
-    return `pdf-upload:${req.userId || req.ip}`;
+    return String(req.userId || getClientIp(req));
   },
+  store: createRedisStore('upload'),
   message: {
     error: 'Too many uploads. Please wait a moment before uploading more files.',
   },

--- a/backend/src/middleware/rate-limit-store.ts
+++ b/backend/src/middleware/rate-limit-store.ts
@@ -1,0 +1,26 @@
+import RedisStore from 'rate-limit-redis';
+import Redis from 'ioredis';
+import { config } from '../config/index.js';
+import { Request } from 'express';
+
+const redisClient = new Redis(config.redis.url);
+
+redisClient.on('error', (err) => {
+  console.error('Rate limit Redis error:', err);
+});
+
+export function createRedisStore(prefix: string) {
+  return new RedisStore({
+    sendCommand: (...args: string[]) => redisClient.call(args[0], ...args.slice(1)) as any,
+    prefix: `rl:${prefix}:`,
+  });
+}
+
+/** Extract real client IP from X-Forwarded-For (set by Caddy), falling back to req.ip */
+export function getClientIp(req: Request): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.ip || 'unknown';
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express';
 import { z } from 'zod';
+import rateLimit from 'express-rate-limit';
 import {
   createUser,
   findUserByEmail,
@@ -15,8 +16,20 @@ import { generateToken, authenticate, AuthRequest } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js';
 import { sendEmail, generatePasswordResetEmail } from '../services/email.js';
 import { config } from '../config/index.js';
+import { createRedisStore, getClientIp } from '../middleware/rate-limit-store.js';
 
 const router = Router();
+
+// Strict rate limit for auth endpoints to prevent brute force
+const authRateLimit = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 15, // 15 attempts per window
+  keyGenerator: getClientIp,
+  store: createRedisStore('auth'),
+  message: { error: 'Too many login attempts, please try again later.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 const registerSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -50,7 +63,7 @@ const changePasswordSchema = z.object({
 });
 
 // Register
-router.post('/register', validate(registerSchema), async (req, res: Response) => {
+router.post('/register', authRateLimit, validate(registerSchema), async (req, res: Response) => {
   try {
     const { email, password, name, phone } = req.body;
 
@@ -79,7 +92,7 @@ router.post('/register', validate(registerSchema), async (req, res: Response) =>
 });
 
 // Login
-router.post('/login', validate(loginSchema), async (req, res: Response) => {
+router.post('/login', authRateLimit, validate(loginSchema), async (req, res: Response) => {
   try {
     const { email, password } = req.body;
 
@@ -173,7 +186,7 @@ router.post('/change-password', authenticate, validate(changePasswordSchema), as
 });
 
 // Request password reset
-router.post('/forgot-password', validate(forgotPasswordSchema), async (req, res: Response) => {
+router.post('/forgot-password', authRateLimit, validate(forgotPasswordSchema), async (req, res: Response) => {
   try {
     const { email } = req.body;
 


### PR DESCRIPTION
## Summary
- All rate limiters now use Redis store instead of in-memory, so counters survive restarts and are shared properly
- Fixed client IP extraction from `X-Forwarded-For` header — previously all users shared a single rate limit bucket (keyed to Caddy's internal Docker IP)
- Added dedicated auth rate limiter (15 attempts/15min) on login, register, and forgot-password for brute force protection

## Root Cause
The global rate limiter (500 req/15min) used the default in-memory store keyed by `req.ip`. Despite `trust proxy: 1`, requests through Caddy's Docker network resolved to the same internal IP, so all users worldwide shared one bucket. Bot/scanner traffic drained it, blocking legitimate users.

## Test plan
- [ ] Verify app loads without rate limit errors
- [ ] Login/register works normally
- [ ] Full e2e regression test via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)