### PR TITLE
feat: site-wide UI remediation — design tokens, inline styles, components

### DIFF
--- a/frontend/src/components/AddPaymentMethodModal.tsx
+++ b/frontend/src/components/AddPaymentMethodModal.tsx
@@ -29,8 +29,8 @@ export default function AddPaymentMethodModal({ onClose, onAdded }: AddPaymentMe
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
         <div className="flex justify-between items-center mb-4">
-          <h3 className="text-lg font-semibold text-gray-900">Add Payment Method</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <h3 className="text-lg font-semibold text-navy">Add Payment Method</h3>
+          <button onClick={onClose} className="text-surface-400 hover:text-surface-600">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -38,7 +38,7 @@ export default function AddPaymentMethodModal({ onClose, onAdded }: AddPaymentMe
         </div>
 
         {error && (
-          <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg text-sm">
+          <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg text-sm">
             {error}
           </div>
         )}

--- a/frontend/src/components/AddPetModal.tsx
+++ b/frontend/src/components/AddPetModal.tsx
@@ -50,10 +50,10 @@ export default function AddPetModal({ onClose, onPetAdded }: Props) {
       <div className="bg-white rounded-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-xl font-bold text-gray-900">Add New Pet</h2>
+            <h2 className="text-xl font-bold text-navy">Add New Pet</h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600"
+              className="text-surface-400 hover:text-surface-600"
             >
               <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -62,7 +62,7 @@ export default function AddPetModal({ onClose, onPetAdded }: Props) {
           </div>
 
           {error && (
-            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -152,9 +152,9 @@ export default function AddPetModal({ onClose, onPetAdded }: Props) {
                 id="is_fixed"
                 checked={formData.is_fixed || false}
                 onChange={(e) => setFormData({ ...formData, is_fixed: e.target.checked })}
-                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-surface-300 rounded"
               />
-              <label htmlFor="is_fixed" className="ml-2 block text-sm text-gray-700">
+              <label htmlFor="is_fixed" className="ml-2 block text-sm text-surface-700">
                 Spayed / Neutered
               </label>
             </div>

--- a/frontend/src/components/CardAlertsModal.tsx
+++ b/frontend/src/components/CardAlertsModal.tsx
@@ -34,7 +34,7 @@ export default function CardAlertsModal({
       <div className="bg-white rounded-xl max-w-lg w-full p-6 max-h-[90vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-xl font-bold">Edit Emergency Card</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="text-surface-400 hover:text-surface-600">
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/frontend/src/components/CheckoutForm.tsx
+++ b/frontend/src/components/CheckoutForm.tsx
@@ -40,7 +40,7 @@ export default function CheckoutForm({ isSetup, returnUrl, onSuccess, submitLabe
       <PaymentElement />
 
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+        <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg text-sm">
           {error}
         </div>
       )}

--- a/frontend/src/components/EditPetModal.tsx
+++ b/frontend/src/components/EditPetModal.tsx
@@ -59,10 +59,10 @@ export default function EditPetModal({ pet, onClose, onPetUpdated }: Props) {
       <div className="bg-white rounded-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-xl font-bold text-gray-900">Edit {pet.name}</h2>
+            <h2 className="text-xl font-bold text-navy">Edit {pet.name}</h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600"
+              className="text-surface-400 hover:text-surface-600"
             >
               <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -80,7 +80,7 @@ export default function EditPetModal({ pet, onClose, onPetUpdated }: Props) {
           </div>
 
           {error && (
-            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -157,9 +157,9 @@ export default function EditPetModal({ pet, onClose, onPetUpdated }: Props) {
                 id="is_fixed_edit"
                 checked={formData.is_fixed || false}
                 onChange={(e) => setFormData({ ...formData, is_fixed: e.target.checked })}
-                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-surface-300 rounded"
               />
-              <label htmlFor="is_fixed_edit" className="ml-2 block text-sm text-gray-700">
+              <label htmlFor="is_fixed_edit" className="ml-2 block text-sm text-surface-700">
                 Spayed / Neutered
               </label>
             </div>

--- a/frontend/src/components/EmergencyCard.tsx
+++ b/frontend/src/components/EmergencyCard.tsx
@@ -97,40 +97,32 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
   return (
     <div>
       {/* Sticky Header */}
-      <header
-        className="sticky top-0 z-50"
-        style={{ background: 'var(--color-danger)', color: 'white', padding: '14px 16px' }}
-      >
+      <header className="sticky top-0 z-50 bg-danger text-white px-4 py-[14px]">
         <div className="max-w-lg mx-auto flex items-center gap-3">
-          <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: 'rgba(255,255,255,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <div className="w-7 h-7 rounded-sm bg-white/20 flex items-center justify-center">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="white"><rect x="9" y="2" width="6" height="20" rx="2"/><rect x="2" y="9" width="20" height="6" rx="2"/></svg>
           </div>
           <div>
-            <h1 style={{ fontSize: '0.8125rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase' as const, fontFamily: 'var(--font-body)' }}>EMERGENCY PET CARD</h1>
-            <p style={{ fontSize: '0.6875rem', opacity: 0.8, fontFamily: 'var(--font-body)' }}>FureverCare</p>
+            <h1 className="text-[0.8125rem] font-bold tracking-[0.12em] uppercase">EMERGENCY PET CARD</h1>
+            <p className="text-[0.6875rem] opacity-80">FureverCare</p>
           </div>
         </div>
       </header>
 
       {/* Alert Banner */}
       {hasAlerts ? (
-        <div style={{ background: 'var(--color-danger-dark)', padding: '14px 16px' }}>
+        <div className="bg-danger-dark px-4 py-[14px]">
           <div className="max-w-lg mx-auto">
-            <div style={{ color: 'white', fontWeight: 600, fontSize: '0.8125rem', letterSpacing: '0.05em', textTransform: 'uppercase' as const, marginBottom: '10px' }}>
+            <div className="text-white font-semibold text-[0.8125rem] tracking-wide uppercase mb-[10px]">
               {alerts.length} Alert{alerts.length !== 1 ? 's' : ''} for {pet.name}
             </div>
             <div className="flex flex-col gap-2">
               {alerts.map((alert, i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-3"
-                  style={{ background: 'rgba(255,255,255,0.12)', borderRadius: 'var(--radius-sm)', padding: '10px 14px' }}
+                  className="flex items-center gap-3 bg-white/[0.12] rounded-sm px-[14px] py-[10px]"
                 >
-                  <div style={{
-                    width: '28px', height: '28px', borderRadius: '50%',
-                    background: 'rgba(255,255,255,0.15)', display: 'flex',
-                    alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-                  }}>
+                  <div className="w-7 h-7 rounded-full bg-white/[0.15] flex items-center justify-center flex-shrink-0">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="#FFCDD2">
                       {alert.type === 'allergy' && <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>}
                       {alert.type === 'medication' && <path d="M4.22 11.29l5.07-5.07c1.95-1.95 5.12-1.95 7.07 0s1.95 5.12 0 7.07l-5.07 5.07c-1.95 1.95-5.12 1.95-7.07 0s-1.95-5.12 0-7.07z"/>}
@@ -139,8 +131,8 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
                     </svg>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p style={{ color: 'white', fontSize: '0.875rem', fontWeight: 600 }}>{alert.title}</p>
-                    <p style={{ color: 'rgba(255,255,255,0.8)', fontSize: '0.75rem', marginTop: '2px' }}>{alert.detail}</p>
+                    <p className="text-white text-sm font-semibold">{alert.title}</p>
+                    <p className="text-white/80 text-xs mt-[2px]">{alert.detail}</p>
                   </div>
                 </div>
               ))}
@@ -148,13 +140,13 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
           </div>
         </div>
       ) : (
-        <div style={{ background: 'var(--color-success)', color: 'white', padding: '24px 16px', textAlign: 'center' as const }}>
+        <div className="bg-success text-white px-4 py-6 text-center">
           <div className="max-w-lg mx-auto">
-            <div style={{ width: '48px', height: '48px', borderRadius: '50%', background: 'rgba(255,255,255,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 12px', fontSize: '24px' }}>
+            <div className="w-12 h-12 rounded-full bg-white/20 flex items-center justify-center mx-auto mb-3 text-2xl">
               ✓
             </div>
-            <p style={{ fontSize: '0.875rem', fontWeight: 600 }}>No known allergies or critical conditions</p>
-            <p style={{ fontSize: '0.75rem', opacity: 0.9, marginTop: '4px' }}>
+            <p className="text-sm font-semibold">No known allergies or critical conditions</p>
+            <p className="text-xs opacity-90 mt-1">
               {pet.name} &bull; {pet.breed || pet.species}
               {pet.weight_kg ? ` \u2022 ${primaryWeight(pet.weight_kg, pet.weight_unit)}` : ''}
             </p>
@@ -163,15 +155,10 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
       )}
 
       {/* Pet Quick Info */}
-      <div style={{ background: 'var(--color-white)', borderBottom: '1px solid var(--color-surface-200)', padding: '14px 16px' }}>
+      <div className="bg-white border-b border-surface-200 px-4 py-[14px]">
         <div className="max-w-lg mx-auto flex items-center gap-4">
           <div
-            className="flex-shrink-0"
-            style={{
-              width: '72px', height: '72px', borderRadius: '50%',
-              background: 'var(--color-navy)', display: 'flex',
-              alignItems: 'center', justifyContent: 'center', overflow: 'hidden',
-            }}
+            className="flex-shrink-0 w-[72px] h-[72px] rounded-full bg-navy flex items-center justify-center overflow-hidden"
           >
             {photoUrl ? (
               <img src={photoUrl} alt={pet.name} className="w-full h-full object-cover" />
@@ -182,8 +169,8 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
             )}
           </div>
           <div className="flex-1 min-w-0">
-            <h2 style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--font-heading)' }}>{pet.name}</h2>
-            <p style={{ fontSize: '0.875rem', color: 'var(--color-surface-600)' }}>
+            <h2 className="text-2xl font-bold font-heading">{pet.name}</h2>
+            <p className="text-sm text-surface-600">
               {pet.breed && <span className="capitalize">{pet.breed}</span>}
               {pet.breed && pet.sex && ' \u2022 '}
               {pet.sex && <span className="capitalize">{pet.sex}{pet.is_fixed ? ', Fixed' : ''}</span>}
@@ -192,7 +179,7 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
               {pet.weight_kg && ` \u2022 ${primaryWeight(pet.weight_kg, pet.weight_unit)}`}
             </p>
             {pet.microchip_id && (
-              <p style={{ fontSize: '0.6875rem', color: 'var(--color-surface-400)', fontFamily: 'monospace', marginTop: '4px' }}>
+              <p className="text-[0.6875rem] text-surface-400 font-mono mt-1">
                 Microchip: {pet.microchip_id}
               </p>
             )}
@@ -201,30 +188,25 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
       </div>
 
       {/* Content */}
-      <div className="max-w-lg mx-auto px-4 py-4" style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <div className="max-w-lg mx-auto px-4 py-4 flex flex-col gap-5">
 
         {/* Special Instructions */}
         {pet.special_instructions && (
-          <div style={{
-            background: 'var(--color-warning-light)',
-            border: '1px solid #FFF9C4',
-            borderRadius: 'var(--radius-sm)',
-            padding: '16px',
-          }}>
-            <div className="flex items-center gap-2" style={{ marginBottom: '6px' }}>
+          <div className="bg-warning-light border border-[#FFF9C4] rounded-sm p-4">
+            <div className="flex items-center gap-2 mb-[6px]">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="var(--color-warning)"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>
-              <span style={{ fontSize: '0.6875rem', fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.05em', color: '#8B6914' }}>
+              <span className="text-xs font-bold uppercase tracking-wide text-warning-dark">
                 Special Instructions
               </span>
             </div>
-            <p style={{ fontSize: '0.9375rem', lineHeight: 1.6 }}>{pet.special_instructions}</p>
+            <p className="text-[0.9375rem] leading-relaxed">{pet.special_instructions}</p>
           </div>
         )}
 
         {/* Emergency Contacts */}
         <section>
-          <h3 className="flex items-center gap-2" style={{ fontSize: '0.8125rem', fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.05em', color: 'var(--color-surface-700)', marginBottom: '12px' }}>
-            <div style={{ width: '32px', height: '32px', borderRadius: '50%', background: 'var(--color-steel-light)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <h3 className="flex items-center gap-2 text-[0.8125rem] font-bold uppercase tracking-wide text-surface-700 mb-3">
+            <div className="w-8 h-8 rounded-full bg-steel-light flex items-center justify-center">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="var(--color-steel)"><path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/></svg>
             </div>
             Emergency Contacts
@@ -232,14 +214,14 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
           <div className="flex flex-col gap-3">
             {/* Owner */}
             {owner && (
-              <div className="flex items-center gap-3" style={{ padding: '16px', border: '1px solid var(--color-surface-200)', borderRadius: 'var(--radius-md)', background: 'var(--color-white)' }}>
+              <div className="flex items-center gap-3 p-4 border border-surface-200 rounded-lg bg-white">
                 <div className="flex-1 min-w-0">
-                  <div style={{ fontSize: '0.6875rem', fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.05em', color: 'var(--color-surface-500)', marginBottom: '4px' }}>Owner</div>
-                  <div style={{ fontWeight: 500, fontSize: '0.9375rem' }}>{owner.name}</div>
-                  {owner.phone && <div className="text-sm" style={{ color: 'var(--color-surface-500)' }}>{owner.phone}</div>}
+                  <div className="text-xs font-bold uppercase tracking-wide text-surface-500 mb-1">Owner</div>
+                  <div className="font-medium text-[0.9375rem]">{owner.name}</div>
+                  {owner.phone && <div className="text-sm text-surface-500">{owner.phone}</div>}
                 </div>
                 {owner.phone && (
-                  <a href={`tel:${owner.phone}`} className="btn btn-primary btn-sm" style={{ flexShrink: 0 }}>
+                  <a href={`tel:${owner.phone}`} className="btn btn-primary btn-sm flex-shrink-0">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/></svg>
                     Call
                   </a>
@@ -251,13 +233,13 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
               if (emergency_contacts.length === 0) return null;
               const c = emergency_contacts.find(c => c.is_primary) || emergency_contacts[0];
               return (
-                <div className="flex items-center gap-3" style={{ padding: '16px', border: '1px solid var(--color-surface-200)', borderRadius: 'var(--radius-md)', background: 'var(--color-white)' }}>
+                <div className="flex items-center gap-3 p-4 border border-surface-200 rounded-lg bg-white">
                   <div className="flex-1 min-w-0">
-                    <div style={{ fontSize: '0.6875rem', fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.05em', color: 'var(--color-surface-500)', marginBottom: '4px' }}>{c.relationship || 'Emergency Contact'}</div>
-                    <div style={{ fontWeight: 500, fontSize: '0.9375rem' }}>{c.name}</div>
-                    <div className="text-sm" style={{ color: 'var(--color-surface-500)' }}>{c.phone}</div>
+                    <div className="text-xs font-bold uppercase tracking-wide text-surface-500 mb-1">{c.relationship || 'Emergency Contact'}</div>
+                    <div className="font-medium text-[0.9375rem]">{c.name}</div>
+                    <div className="text-sm text-surface-500">{c.phone}</div>
                   </div>
-                  <a href={`tel:${c.phone}`} className="btn btn-primary btn-sm" style={{ flexShrink: 0 }}>
+                  <a href={`tel:${c.phone}`} className="btn btn-primary btn-sm flex-shrink-0">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/></svg>
                     Call
                   </a>
@@ -267,17 +249,17 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
 
             {/* Veterinarians */}
             {veterinarians.map((v, i) => (
-              <div key={i} className="flex items-center gap-3" style={{ padding: '16px', border: '1px solid var(--color-surface-200)', borderRadius: 'var(--radius-md)', background: 'var(--color-white)' }}>
+              <div key={i} className="flex items-center gap-3 p-4 border border-surface-200 rounded-lg bg-white">
                 <div className="flex-1 min-w-0">
-                  <div style={{ fontSize: '0.6875rem', fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.05em', color: 'var(--color-surface-500)', marginBottom: '4px' }}>
+                  <div className="text-xs font-bold uppercase tracking-wide text-surface-500 mb-1">
                     Veterinarian{v.is_primary ? ' (Primary)' : ''}
                   </div>
-                  <div style={{ fontWeight: 500, fontSize: '0.9375rem' }}>{v.clinic_name}</div>
-                  {v.vet_name && <div className="text-sm" style={{ color: 'var(--color-surface-500)' }}>Dr. {v.vet_name}</div>}
-                  {v.phone && <div className="text-sm" style={{ color: 'var(--color-surface-500)' }}>{v.phone}</div>}
+                  <div className="font-medium text-[0.9375rem]">{v.clinic_name}</div>
+                  {v.vet_name && <div className="text-sm text-surface-500">Dr. {v.vet_name}</div>}
+                  {v.phone && <div className="text-sm text-surface-500">{v.phone}</div>}
                 </div>
                 {v.phone && (
-                  <a href={`tel:${v.phone}`} className="btn btn-primary btn-sm" style={{ flexShrink: 0 }}>
+                  <a href={`tel:${v.phone}`} className="btn btn-primary btn-sm flex-shrink-0">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/></svg>
                     Call
                   </a>
@@ -289,9 +271,9 @@ export default function EmergencyCard({ card, resolvePhotoUrl }: Props) {
       </div>
 
       {/* Footer */}
-      <footer style={{ background: 'var(--color-surface)', borderTop: '1px solid var(--color-surface-200)', textAlign: 'center' as const, padding: '16px', fontSize: '0.8125rem', color: 'var(--color-surface-500)' }}>
+      <footer className="bg-surface border-t border-surface-200 text-center p-4 text-[0.8125rem] text-surface-500">
         Last updated {new Date(card.generated_at).toLocaleDateString()} &bull; Powered by{' '}
-        <Link to="/" style={{ color: 'var(--color-navy)', fontWeight: 500, textDecoration: 'none' }}>FureverCare</Link>
+        <Link to="/" className="text-navy font-medium no-underline">FureverCare</Link>
       </footer>
     </div>
   );

--- a/frontend/src/components/EmergencyCardView.tsx
+++ b/frontend/src/components/EmergencyCardView.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export default function EmergencyCardView({ card, resolvePhotoUrl }: Props) {
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--color-surface-100)' }}>
+    <div className="min-h-screen bg-surface-100">
       <EmergencyCard card={card} resolvePhotoUrl={resolvePhotoUrl} />
     </div>
   );

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  compact?: boolean;
+}
+
+export default function EmptyState({ icon, title, description, action, compact = false }: EmptyStateProps) {
+  return (
+    <div className={`flex flex-col items-center justify-center text-center ${compact ? 'py-4' : 'py-12'}`}>
+      {icon && <div className={compact ? 'mb-2' : 'mb-3'}>{icon}</div>}
+      <p className={compact ? 'text-surface-500 text-sm' : 'text-navy text-lg font-semibold'}>{title}</p>
+      {description && <p className="text-surface-500 text-sm mt-1">{description}</p>}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/FlexibleDateInput.tsx
+++ b/frontend/src/components/FlexibleDateInput.tsx
@@ -134,7 +134,7 @@ export default function FlexibleDateInput({ value, precision, onChange, label, r
 
   return (
     <div>
-      {label && <label className="text-sm text-gray-600">{label}{required && ' *'}</label>}
+      {label && <label className="text-sm text-surface-600">{label}{required && ' *'}</label>}
       <div className="grid grid-cols-3 gap-2">
         <div>
           <select

--- a/frontend/src/components/InlineEditForm.tsx
+++ b/frontend/src/components/InlineEditForm.tsx
@@ -94,7 +94,7 @@ function AutocompleteSelect({ field, value, onChange }: { field: EditField; valu
 
   return (
     <div key={field.key}>
-      {field.label && <label className="text-sm text-gray-600">{field.label}</label>}
+      {field.label && <label className="text-sm text-surface-600">{field.label}</label>}
       <div className="relative">
         <input
           ref={inputRef}
@@ -108,7 +108,7 @@ function AutocompleteSelect({ field, value, onChange }: { field: EditField; valu
           autoComplete="off"
         />
         {isOpen && filtered.length > 0 && (
-          <div ref={dropdownRef} className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-lg shadow-lg max-h-60 overflow-auto">
+          <div ref={dropdownRef} className="absolute z-10 w-full mt-1 bg-white border border-surface-300 rounded-lg shadow-lg max-h-60 overflow-auto">
             {filtered.map((o, index) => (
               <button
                 key={o.value}
@@ -116,7 +116,7 @@ function AutocompleteSelect({ field, value, onChange }: { field: EditField; valu
                 onClick={() => { onChange(o.value); setIsOpen(false); setHighlightedIndex(-1); inputRef.current?.focus(); }}
                 onMouseEnter={() => setHighlightedIndex(index)}
                 className={`w-full text-left px-3 py-2 hover:bg-primary-50 transition-colors ${
-                  index === highlightedIndex ? 'bg-primary-50 text-primary-900' : 'text-gray-900'
+                  index === highlightedIndex ? 'bg-primary-50 text-primary-900' : 'text-navy'
                 }`}
               >
                 {o.label}
@@ -155,9 +155,9 @@ export default function InlineEditForm({ fields, values: initialValues, onSave, 
             id={`edit-${field.key}`}
             checked={val as boolean}
             onChange={(e) => setValue(field.key, e.target.checked)}
-            className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+            className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-surface-300 rounded"
           />
-          <label htmlFor={`edit-${field.key}`} className="ml-2 block text-sm text-gray-700">
+          <label htmlFor={`edit-${field.key}`} className="ml-2 block text-sm text-surface-700">
             {field.placeholder}
           </label>
         </div>
@@ -196,7 +196,7 @@ export default function InlineEditForm({ fields, values: initialValues, onSave, 
     if (field.type === 'textarea') {
       return (
         <div key={field.key}>
-          {field.label && <label className="text-sm text-gray-600">{field.label}</label>}
+          {field.label && <label className="text-sm text-surface-600">{field.label}</label>}
           <textarea
             placeholder={field.placeholder}
             value={val as string}
@@ -210,7 +210,7 @@ export default function InlineEditForm({ fields, values: initialValues, onSave, 
 
     return (
       <div key={field.key}>
-        {field.label && <label className="text-sm text-gray-600">{field.label}</label>}
+        {field.label && <label className="text-sm text-surface-600">{field.label}</label>}
         <input
           type={field.type || 'text'}
           placeholder={field.placeholder}
@@ -251,7 +251,7 @@ export default function InlineEditForm({ fields, values: initialValues, onSave, 
   };
 
   return (
-    <div className={`bg-gray-50 rounded-lg p-4 space-y-3 ${className}`}>
+    <div className={`bg-surface rounded-lg p-4 space-y-3 ${className}`}>
       {renderFields()}
       <div className="flex gap-2">
         <button onClick={handleSave} className="btn-primary text-sm">Save</button>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,18 +11,18 @@ export default function Layout() {
   };
 
   return (
-    <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
-      <nav style={{ padding: '12px 0', background: 'var(--color-white)', borderBottom: '1px solid var(--color-surface-200)' }}>
+    <div className="min-h-screen bg-surface">
+      <nav className="py-3 bg-white border-b border-surface-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
           <Link to="/dashboard" className="flex items-center gap-2">
-            <svg width="32" height="32" viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none" className="shrink-0">
               <rect width="32" height="32" rx="10" fill="#1B2A4A"/>
               <circle cx="11" cy="12" r="2" fill="#4A7FB5"/>
               <circle cx="21" cy="12" r="2" fill="#4A7FB5"/>
               <circle cx="16" cy="16" r="1.5" fill="#4A7FB5"/>
               <path d="M9 20c0-3.9 3.1-7 7-7s7 3.1 7 7" stroke="#4A7FB5" strokeWidth="2" strokeLinecap="round"/>
             </svg>
-            <span style={{ fontFamily: 'var(--font-heading)', fontSize: '1.125rem', color: 'var(--color-navy)', fontWeight: 600 }}>
+            <span className="font-heading text-lg text-navy font-semibold">
               FureverCare
             </span>
           </Link>
@@ -31,23 +31,20 @@ export default function Layout() {
             {isAdmin && (
               <Link
                 to="/admin"
-                className="text-sm font-medium"
-                style={{ color: 'var(--color-steel)', textDecoration: 'none' }}
+                className="text-sm font-medium text-steel no-underline"
               >
                 Admin
               </Link>
             )}
             <Link
               to="/settings"
-              className="text-sm font-medium"
-              style={{ color: 'var(--color-surface-600)', textDecoration: 'none' }}
+              className="text-sm font-medium text-surface-600 no-underline"
             >
               {user?.name || 'Settings'}
             </Link>
             <button
               onClick={handleLogout}
-              className="text-sm font-medium"
-              style={{ color: 'var(--color-surface-600)', background: 'none', border: 'none', cursor: 'pointer' }}
+              className="text-sm font-medium text-surface-600 bg-transparent border-none cursor-pointer"
             >
               Logout
             </button>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,7 +12,7 @@ export default function Layout() {
 
   return (
     <div className="min-h-screen bg-surface">
-      <nav className="py-3 bg-white border-b border-surface-200">
+      <nav className="py-3 bg-white border-b border-surface-200 shadow-token-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
           <Link to="/dashboard" className="flex items-center gap-2">
             <svg width="32" height="32" viewBox="0 0 32 32" fill="none" className="shrink-0">
@@ -38,13 +38,13 @@ export default function Layout() {
             )}
             <Link
               to="/settings"
-              className="text-sm font-medium text-surface-600 no-underline"
+              className="text-sm font-medium text-surface-600 no-underline hover:text-navy transition-colors"
             >
               {user?.name || 'Settings'}
             </Link>
             <button
               onClick={handleLogout}
-              className="text-sm font-medium text-surface-600 bg-transparent border-none cursor-pointer"
+              className="text-sm font-medium text-surface-600 bg-transparent border-none cursor-pointer hover:text-navy transition-colors"
             >
               Logout
             </button>
@@ -52,7 +52,7 @@ export default function Layout() {
         </div>
       </nav>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/ManageAccessModal.tsx
+++ b/frontend/src/components/ManageAccessModal.tsx
@@ -145,8 +145,8 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
       case 'owner': return 'bg-purple-100 text-purple-700';
-      case 'editor': return 'bg-blue-100 text-blue-700';
-      default: return 'bg-gray-100 text-gray-700';
+      case 'editor': return 'bg-info-light text-info';
+      default: return 'bg-surface-100 text-surface-700';
     }
   };
 
@@ -155,8 +155,8 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
       <div className="bg-white rounded-xl max-w-lg w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-xl font-bold text-gray-900">Manage Access - {petName}</h2>
-            <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <h2 className="text-xl font-bold text-navy">Manage Access - {petName}</h2>
+            <button onClick={onClose} className="text-surface-400 hover:text-surface-600">
               <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
@@ -164,13 +164,13 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
           </div>
 
           {error && (
-            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
 
           {inviteSuccess && (
-            <div className="mb-4 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-lg text-sm break-all">
+            <div className="mb-4 bg-success-light border border-success-light text-success px-4 py-3 rounded-lg text-sm break-all">
               {inviteSuccess}
             </div>
           )}
@@ -183,13 +183,13 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
             <>
               {/* Current Users */}
               <div className="mb-6">
-                <h3 className="text-sm font-medium text-gray-700 mb-3">People with access</h3>
+                <h3 className="text-sm font-medium text-surface-700 mb-3">People with access</h3>
                 <ul className="space-y-2">
                   {owners.map((owner) => (
-                    <li key={owner.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                    <li key={owner.id} className="flex items-center justify-between p-3 bg-surface rounded-lg">
                       <div>
-                        <p className="font-medium text-gray-900">{owner.user_name}</p>
-                        <p className="text-sm text-gray-500">{owner.user_email}</p>
+                        <p className="font-medium text-navy">{owner.user_name}</p>
+                        <p className="text-sm text-surface-500">{owner.user_email}</p>
                       </div>
                       <div className="flex items-center gap-2">
                         {owner.role === 'owner' ? (
@@ -208,7 +208,7 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
                             </select>
                             <button
                               onClick={() => handleRemoveUser(owner.user_id)}
-                              className="text-red-600 hover:text-red-800 text-sm"
+                              className="text-danger hover:text-danger-dark text-sm"
                             >
                               Remove
                             </button>
@@ -227,19 +227,19 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
               {/* Pending Invitations */}
               {isOwner && invitations.length > 0 && (
                 <div className="mb-6">
-                  <h3 className="text-sm font-medium text-gray-700 mb-3">Pending invitations</h3>
+                  <h3 className="text-sm font-medium text-surface-700 mb-3">Pending invitations</h3>
                   <ul className="space-y-2">
                     {invitations.map((inv) => (
-                      <li key={inv.id} className="flex items-center justify-between p-3 bg-yellow-50 rounded-lg">
+                      <li key={inv.id} className="flex items-center justify-between p-3 bg-warning-light rounded-lg">
                         <div>
-                          <p className="font-medium text-gray-900">{inv.email}</p>
-                          <p className="text-xs text-gray-500">
+                          <p className="font-medium text-navy">{inv.email}</p>
+                          <p className="text-xs text-surface-500">
                             {inv.role} • Expires {new Date(inv.expires_at).toLocaleDateString()}
                           </p>
                         </div>
                         <button
                           onClick={() => handleCancelInvitation(inv.id)}
-                          className="text-red-600 hover:text-red-800 text-sm"
+                          className="text-danger hover:text-danger-dark text-sm"
                         >
                           Cancel
                         </button>
@@ -252,7 +252,7 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
               {/* Invite Form */}
               {isOwner && (
                 <div className="border-t pt-4">
-                  <h3 className="text-sm font-medium text-gray-700 mb-3">Invite someone</h3>
+                  <h3 className="text-sm font-medium text-surface-700 mb-3">Invite someone</h3>
                   <div className="flex gap-2">
                     <input
                       type="email"
@@ -277,7 +277,7 @@ export default function ManageAccessModal({ petId, petName, onClose }: Props) {
                       {isInviting ? '...' : 'Invite'}
                     </button>
                   </div>
-                  <p className="text-xs text-gray-500 mt-2">
+                  <p className="text-xs text-surface-500 mt-2">
                     Viewers can see all pet info. Editors can also add/edit health records.
                   </p>
                 </div>

--- a/frontend/src/components/MedicalTimeline.tsx
+++ b/frontend/src/components/MedicalTimeline.tsx
@@ -46,9 +46,9 @@ const eventTypeConfig: Record<EventType, { label: string; icon: string; bgColor:
   medication_start: {
     label: 'Medication Started',
     icon: '💊',
-    bgColor: 'bg-blue-50',
-    textColor: 'text-blue-700',
-    borderColor: 'border-blue-300',
+    bgColor: 'bg-info-light',
+    textColor: 'text-info',
+    borderColor: 'border-info',
   },
   medication_end: {
     label: 'Medication Ended',
@@ -67,9 +67,9 @@ const eventTypeConfig: Record<EventType, { label: string; icon: string; bgColor:
   allergy: {
     label: 'Allergy Identified',
     icon: '⚠️',
-    bgColor: 'bg-red-50',
-    textColor: 'text-red-700',
-    borderColor: 'border-red-300',
+    bgColor: 'bg-danger-light',
+    textColor: 'text-danger',
+    borderColor: 'border-danger-light',
   },
 };
 
@@ -236,8 +236,8 @@ export function MedicalTimeline({ conditions, allergies, medications, vaccinatio
     return (
       <div className="text-center py-12">
         <div className="text-4xl mb-4">📋</div>
-        <p className="text-gray-500">No medical events recorded yet</p>
-        <p className="text-sm text-gray-400 mt-2">
+        <p className="text-surface-500">No medical events recorded yet</p>
+        <p className="text-sm text-surface-400 mt-2">
           Add vaccinations, medications, conditions, or allergies to see them on the timeline
         </p>
       </div>
@@ -280,7 +280,7 @@ export function MedicalTimeline({ conditions, allergies, medications, vaccinatio
                 className={`px-3 py-1 text-xs font-semibold rounded-full border transition-colors ${
                   isActive
                     ? 'text-white border-transparent'
-                    : 'bg-white text-gray-500 hover:text-gray-700'
+                    : 'bg-white text-surface-500 hover:text-surface-700'
                 }`}
                 style={isActive ? {
                   background: 'var(--color-navy, #1B2A4A)',
@@ -295,7 +295,7 @@ export function MedicalTimeline({ conditions, allergies, medications, vaccinatio
           })}
         </div>
         <div className="flex items-center gap-3">
-          <p className="text-sm text-gray-500">{events.length} event{events.length !== 1 ? 's' : ''}</p>
+          <p className="text-sm text-surface-500">{events.length} event{events.length !== 1 ? 's' : ''}</p>
           <button
             onClick={() => setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc')}
             className="btn-secondary text-sm py-1.5 px-3 flex items-center gap-1"
@@ -308,14 +308,14 @@ export function MedicalTimeline({ conditions, allergies, medications, vaccinatio
       {/* Timeline */}
       <div className="relative">
         {/* Vertical line */}
-        <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-gray-200" />
+        <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-surface-200" />
 
         {groupedEvents.map((group) => (
           <div key={group.label} className="mb-6">
             {/* Month/Year header */}
             <div className="relative flex items-center mb-4">
-              <div className="absolute left-2.5 w-3 h-3 rounded-full bg-gray-300 border-2 border-white" />
-              <span className="ml-10 text-sm font-medium text-gray-500">{group.label}</span>
+              <div className="absolute left-2.5 w-3 h-3 rounded-full bg-surface-300 border-2 border-white" />
+              <span className="ml-10 text-sm font-medium text-surface-500">{group.label}</span>
             </div>
 
             {/* Events in this group */}
@@ -339,10 +339,10 @@ export function MedicalTimeline({ conditions, allergies, medications, vaccinatio
                           {event.severity && (
                             <span className={`text-xs px-1.5 py-0.5 rounded capitalize ${
                               event.severity === 'severe' || event.severity === 'life-threatening'
-                                ? 'bg-red-100 text-red-700'
+                                ? 'bg-danger-light text-danger'
                                 : event.severity === 'moderate'
-                                ? 'bg-yellow-100 text-yellow-700'
-                                : 'bg-gray-100 text-gray-600'
+                                ? 'bg-warning-light text-warning-dark'
+                                : 'bg-surface-100 text-surface-600'
                             }`}>
                               {event.severity}
                             </span>
@@ -350,34 +350,34 @@ export function MedicalTimeline({ conditions, allergies, medications, vaccinatio
                           {event.isActive !== undefined && (
                             <span className={`text-xs px-1.5 py-0.5 rounded ${
                               event.isActive
-                                ? 'bg-green-100 text-green-700'
-                                : 'bg-gray-100 text-gray-500'
+                                ? 'bg-success-light text-success'
+                                : 'bg-surface-100 text-surface-500'
                             }`}>
                               {event.isActive ? 'Active' : 'Inactive'}
                             </span>
                           )}
                           {event.isExpired && (
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-red-100 text-red-700">
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-danger-light text-danger">
                               Expired
                             </span>
                           )}
                         </div>
-                        <p className="font-medium text-gray-900 mt-1">{event.title}</p>
+                        <p className="font-medium text-navy mt-1">{event.title}</p>
                         {event.subtitle && (
-                          <p className="text-sm text-gray-600">{event.subtitle}</p>
+                          <p className="text-sm text-surface-600">{event.subtitle}</p>
                         )}
                         {event.details && event.details.length > 0 && (
-                          <ul className="text-sm text-gray-500 mt-1 space-y-0.5">
+                          <ul className="text-sm text-surface-500 mt-1 space-y-0.5">
                             {event.details.map((detail, i) => (
                               <li key={i}>{detail}</li>
                             ))}
                           </ul>
                         )}
                       </div>
-                      <div className="text-right text-sm text-gray-500 whitespace-nowrap">
+                      <div className="text-right text-sm text-surface-500 whitespace-nowrap">
                         <div>{formatFlexibleDate(event.dateStr, event.datePrecision)}</div>
                         {parsedDob && event.date >= parsedDob && (
-                          <div className="text-xs text-gray-400">
+                          <div className="text-xs text-surface-400">
                             {calculateAge(parsedDob, event.date)}
                           </div>
                         )}

--- a/frontend/src/components/PaymentMethodList.tsx
+++ b/frontend/src/components/PaymentMethodList.tsx
@@ -77,26 +77,26 @@ export default function PaymentMethodList() {
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-base font-semibold text-gray-900">Payment Methods</h3>
+        <h3 className="text-base font-semibold text-navy">Payment Methods</h3>
         <button onClick={() => setShowAddModal(true)} className="text-sm text-primary-600 hover:text-primary-500 font-medium">
           Add method
         </button>
       </div>
 
       {error && (
-        <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg text-sm">
+        <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg text-sm">
           {error}
         </div>
       )}
 
       {methods.length === 0 ? (
-        <p className="text-gray-500 text-sm">No payment methods on file.</p>
+        <p className="text-surface-500 text-sm">No payment methods on file.</p>
       ) : (
-        <ul className="divide-y divide-gray-200">
+        <ul className="divide-y divide-surface-200">
           {methods.map((method) => (
             <li key={method.id} className="py-3 flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <span className="text-sm text-gray-900">{formatMethod(method)}</span>
+                <span className="text-sm text-navy">{formatMethod(method)}</span>
                 {method.isDefault && (
                   <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800">
                     Default
@@ -116,7 +116,7 @@ export default function PaymentMethodList() {
                 <button
                   onClick={() => handleRemove(method.id)}
                   disabled={actionLoading === method.id}
-                  className="text-xs text-red-600 hover:text-red-500 font-medium disabled:opacity-50"
+                  className="text-xs text-danger hover:text-danger-dark font-medium disabled:opacity-50"
                 >
                   Remove
                 </button>

--- a/frontend/src/components/PhotoUpload.tsx
+++ b/frontend/src/components/PhotoUpload.tsx
@@ -183,14 +183,14 @@ export default function PhotoUpload({ petId, currentPhotoUrl, onPhotoUpdated, co
           <button
             onClick={handleDeletePhoto}
             disabled={isUploading}
-            className="btn text-sm text-red-600 hover:bg-red-50"
+            className="btn text-sm text-danger hover:bg-danger-light"
           >
             Remove
           </button>
         )}
       </div>
 
-      <p className="text-xs text-gray-400 mt-1">JPEG, PNG, WebP, GIF, HEIC, TIFF, BMP up to 10MB</p>
+      <p className="text-xs text-surface-400 mt-1">JPEG, PNG, WebP, GIF, HEIC, TIFF, BMP up to 10MB</p>
 
       {error && <p className="error-text mt-2">{error}</p>}
     </div>

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -22,7 +22,7 @@ export default function ShareModal({ petName, shareUrl, onClose, onManageLinks }
       <div className="bg-white rounded-xl max-w-md w-full p-6">
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-xl font-bold">Share {petName}'s Card</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="text-surface-400 hover:text-surface-600">
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -34,7 +34,7 @@ export default function ShareModal({ petName, shareUrl, onClose, onManageLinks }
             <QRCodeSVG value={shareUrl} size={200} />
           </div>
 
-          <p className="text-sm text-gray-600 mb-4">
+          <p className="text-sm text-surface-600 mb-4">
             Scan this QR code or share the link below to give ER staff instant access to {petName}'s health information.
           </p>
 
@@ -53,7 +53,7 @@ export default function ShareModal({ petName, shareUrl, onClose, onManageLinks }
             </button>
           </div>
 
-          <p className="text-xs text-gray-400 mb-4">
+          <p className="text-xs text-surface-400 mb-4">
             This link provides read-only access. No login required.
           </p>
 

--- a/frontend/src/components/ShareWallet.tsx
+++ b/frontend/src/components/ShareWallet.tsx
@@ -134,9 +134,9 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
         <div className="flex justify-between items-center p-6 border-b">
           <div>
             <h2 className="text-xl font-bold">Custom Share Links</h2>
-            <p className="text-sm text-gray-500">Create time-limited or PIN-protected links for {petName}</p>
+            <p className="text-sm text-surface-500">Create time-limited or PIN-protected links for {petName}</p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="text-surface-400 hover:text-surface-600">
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -149,7 +149,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
             <div className="space-y-4">
               {/* Create New Link Button */}
               <div className="flex items-center justify-between">
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-surface-600">
                   Create links for pet sitters, boarding, or temporary access.
                 </p>
                 <button
@@ -161,9 +161,9 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
               </div>
 
               {isLoading ? (
-                <div className="text-center py-8 text-gray-500">Loading...</div>
+                <div className="text-center py-8 text-surface-500">Loading...</div>
               ) : tokens.length === 0 ? (
-                <div className="text-center py-12 text-gray-500">
+                <div className="text-center py-12 text-surface-500">
                   <p className="mb-2">No custom share links yet</p>
                   <p className="text-sm">Use these for pet sitters, boarding facilities, or anyone who needs temporary access.</p>
                 </div>
@@ -176,23 +176,23 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                     >
                       <div className="flex items-start justify-between mb-2">
                         <div>
-                          <h4 className="font-medium text-gray-900">
+                          <h4 className="font-medium text-navy">
                             {t.label || 'Unnamed Link'}
                           </h4>
-                          <div className="flex items-center gap-2 text-xs text-gray-500">
-                            {t.has_pin && <span className="bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">PIN</span>}
+                          <div className="flex items-center gap-2 text-xs text-surface-500">
+                            {t.has_pin && <span className="bg-info-light text-info px-1.5 py-0.5 rounded">PIN</span>}
                             <span>{formatExpiry(t.expires_at)}</span>
                           </div>
                         </div>
                         {t.is_expired ? (
-                          <span className="text-xs bg-red-100 text-red-700 px-2 py-1 rounded">Expired</span>
+                          <span className="text-xs bg-danger-light text-danger px-2 py-1 rounded">Expired</span>
                         ) : !t.is_active ? (
-                          <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">Deactivated</span>
+                          <span className="text-xs bg-surface-100 text-surface-600 px-2 py-1 rounded">Deactivated</span>
                         ) : (
-                          <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded">Active</span>
+                          <span className="text-xs bg-success-light text-success px-2 py-1 rounded">Active</span>
                         )}
                       </div>
-                      <p className="text-xs text-gray-400 mb-3">
+                      <p className="text-xs text-surface-400 mb-3">
                         {formatLastAccess(t.last_accessed_at, t.access_count)}
                       </p>
                       <div className="flex gap-2">
@@ -213,7 +213,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                         </button>
                         <button
                           onClick={() => handleDelete(t.id)}
-                          className="text-red-600 hover:text-red-800 text-sm px-2"
+                          className="text-danger hover:text-danger-dark text-sm px-2"
                         >
                           Delete
                         </button>
@@ -229,7 +229,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
             <div className="space-y-4">
               <button
                 onClick={() => setViewMode('list')}
-                className="text-sm text-gray-600 hover:text-gray-900 flex items-center gap-1"
+                className="text-sm text-surface-600 hover:text-navy flex items-center gap-1"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -238,11 +238,11 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
               </button>
 
               <div>
-                <h3 className="font-medium text-gray-900 mb-4">Create Custom Share Link</h3>
+                <h3 className="font-medium text-navy mb-4">Create Custom Share Link</h3>
 
                 <div className="space-y-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-surface-700 mb-1">
                       Label (optional)
                     </label>
                     <input
@@ -255,7 +255,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-surface-700 mb-1">
                       Expiration
                     </label>
                     <select
@@ -272,7 +272,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-surface-700 mb-1">
                       PIN Protection (optional)
                     </label>
                     <input
@@ -283,7 +283,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                       maxLength={20}
                       className="input"
                     />
-                    <p className="text-xs text-gray-500 mt-1">
+                    <p className="text-xs text-surface-500 mt-1">
                       4-20 characters. Viewers must enter this PIN to see the card.
                     </p>
                   </div>
@@ -309,7 +309,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                   setSelectedToken(null);
                   setViewMode('list');
                 }}
-                className="text-sm text-gray-600 hover:text-gray-900 flex items-center gap-1"
+                className="text-sm text-surface-600 hover:text-navy flex items-center gap-1"
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -318,12 +318,12 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
               </button>
 
               <div className="text-center">
-                <h3 className="font-medium text-gray-900 mb-1">
+                <h3 className="font-medium text-navy mb-1">
                   {selectedToken.label || 'Share Link'}
                 </h3>
-                <div className="flex items-center justify-center gap-2 text-sm text-gray-500 mb-4">
+                <div className="flex items-center justify-center gap-2 text-sm text-surface-500 mb-4">
                   {selectedToken.has_pin && (
-                    <span className="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs">PIN Protected</span>
+                    <span className="bg-info-light text-info px-2 py-0.5 rounded text-xs">PIN Protected</span>
                   )}
                   <span>{formatExpiry(selectedToken.expires_at)}</span>
                 </div>
@@ -332,7 +332,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                   <QRCodeSVG value={getShareUrl(selectedToken.token)} size={200} />
                 </div>
 
-                <p className="text-sm text-gray-600 mb-4">
+                <p className="text-sm text-surface-600 mb-4">
                   Scan this QR code to access {petName}'s emergency health card.
                   {selectedToken.has_pin && ' A PIN will be required.'}
                 </p>
@@ -352,7 +352,7 @@ export default function ShareWallet({ petId, petName, onClose }: ShareWalletProp
                   </button>
                 </div>
 
-                <p className="text-xs text-gray-400 mt-4">
+                <p className="text-xs text-surface-400 mt-4">
                   {formatLastAccess(selectedToken.last_accessed_at, selectedToken.access_count)}
                 </p>
               </div>

--- a/frontend/src/components/SourceDocumentLink.tsx
+++ b/frontend/src/components/SourceDocumentLink.tsx
@@ -36,7 +36,7 @@ export default function SourceDocumentLink({ petId, recordType, recordId, onNavi
           onNavigateToReview(source.upload_id, source.extraction_item_id);
         }
       }}
-      className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 hover:underline mt-0.5"
+      className="inline-flex items-center gap-1 text-xs text-info hover:text-info hover:underline mt-0.5"
       title={`Imported from ${filename}`}
     >
       <svg className="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">

--- a/frontend/src/components/UpgradeBanner.tsx
+++ b/frontend/src/components/UpgradeBanner.tsx
@@ -56,7 +56,7 @@ export default function UpgradeBanner({ type, feature, petCount, petLimit }: Upg
 
         <Link
           to="/pricing"
-          className="flex-shrink-0 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-accent-500 shadow-sm transition-all hover:bg-gray-50 hover:shadow-md"
+          className="flex-shrink-0 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-accent-500 shadow-sm transition-all hover:bg-surface hover:shadow-md"
         >
           Upgrade
         </Link>

--- a/frontend/src/components/audit/AuditLogEntry.tsx
+++ b/frontend/src/components/audit/AuditLogEntry.tsx
@@ -17,7 +17,7 @@ const ENTITY_TYPE_LABELS: Record<string, string> = {
 const ACTION_CONFIG: Record<string, { label: string; color: string; icon: React.ReactNode }> = {
   create: {
     label: 'Added',
-    color: 'text-green-600 bg-green-50',
+    color: 'text-success bg-success-light',
     icon: (
       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -26,7 +26,7 @@ const ACTION_CONFIG: Record<string, { label: string; color: string; icon: React.
   },
   update: {
     label: 'Updated',
-    color: 'text-blue-600 bg-blue-50',
+    color: 'text-info bg-info-light',
     icon: (
       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -35,7 +35,7 @@ const ACTION_CONFIG: Record<string, { label: string; color: string; icon: React.
   },
   delete: {
     label: 'Removed',
-    color: 'text-red-600 bg-red-50',
+    color: 'text-danger bg-danger-light',
     icon: (
       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -79,7 +79,7 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
   const renderChanges = () => {
     if (entry.action === 'create' && entry.new_values) {
       return (
-        <div className="mt-2 text-xs text-gray-500">
+        <div className="mt-2 text-xs text-surface-500">
           <div className="grid grid-cols-2 gap-x-4 gap-y-1">
             {Object.entries(entry.new_values)
               .filter(([key]) => !['id', 'pet_id', 'created_at', 'updated_at'].includes(key))
@@ -87,7 +87,7 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
               .map(([key, value]) => (
                 <div key={key} className="flex justify-between">
                   <span className="font-medium capitalize">{key.replace(/_/g, ' ')}:</span>
-                  <span className="text-gray-700">{formatValue(value)}</span>
+                  <span className="text-surface-700">{formatValue(value)}</span>
                 </div>
               ))}
           </div>
@@ -100,10 +100,10 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
         <div className="mt-2 text-xs space-y-1">
           {entry.changed_fields.map((field) => (
             <div key={field} className="flex items-center gap-2">
-              <span className="font-medium text-gray-500 capitalize">{field.replace(/_/g, ' ')}:</span>
-              <span className="text-red-500 line-through">{formatValue(entry.old_values![field])}</span>
-              <span className="text-gray-400">→</span>
-              <span className="text-green-600">{formatValue(entry.new_values![field])}</span>
+              <span className="font-medium text-surface-500 capitalize">{field.replace(/_/g, ' ')}:</span>
+              <span className="text-danger line-through">{formatValue(entry.old_values![field])}</span>
+              <span className="text-surface-400">→</span>
+              <span className="text-success">{formatValue(entry.new_values![field])}</span>
             </div>
           ))}
         </div>
@@ -112,8 +112,8 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
 
     if (entry.action === 'delete' && entry.old_values) {
       return (
-        <div className="mt-2 text-xs text-gray-500">
-          <span className="text-red-500">Deleted record</span>
+        <div className="mt-2 text-xs text-surface-500">
+          <span className="text-danger">Deleted record</span>
           {recordName && <span>: {recordName}</span>}
         </div>
       );
@@ -123,7 +123,7 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
   };
 
   return (
-    <div className="py-4 border-b border-gray-100 last:border-0">
+    <div className="py-4 border-b border-surface-100 last:border-0">
       <div className="flex items-start gap-3">
         {/* Action icon */}
         <div className={`p-2 rounded-full ${actionConfig.color}`}>
@@ -136,9 +136,9 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
             <span className={`font-medium ${actionConfig.color.split(' ')[0]}`}>
               {actionConfig.label}
             </span>
-            <span className="text-gray-900">{entityLabel}</span>
+            <span className="text-navy">{entityLabel}</span>
             {recordName && (
-              <span className="text-gray-500">"{recordName}"</span>
+              <span className="text-surface-500">"{recordName}"</span>
             )}
             {entry.source === 'pdf_import' && (
               <span className="text-xs bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded">
@@ -147,7 +147,7 @@ export function AuditLogEntry({ entry }: AuditLogEntryProps) {
             )}
           </div>
 
-          <div className="mt-1 text-xs text-gray-500 flex items-center gap-2">
+          <div className="mt-1 text-xs text-surface-500 flex items-center gap-2">
             <span>{formatDate(entry.created_at)}</span>
             {entry.changed_by_name && (
               <>

--- a/frontend/src/components/audit/AuditLogViewer.tsx
+++ b/frontend/src/components/audit/AuditLogViewer.tsx
@@ -82,8 +82,8 @@ export function AuditLogViewer({ petId }: AuditLogViewerProps) {
 
   if (error && logs.length === 0) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-        <p className="text-red-600">{error}</p>
+      <div className="bg-danger-light border border-danger-light rounded-lg p-4">
+        <p className="text-danger">{error}</p>
       </div>
     );
   }
@@ -93,11 +93,11 @@ export function AuditLogViewer({ petId }: AuditLogViewerProps) {
       {/* Filters */}
       <div className="flex items-center gap-4 flex-wrap">
         <div>
-          <label className="block text-xs font-medium text-gray-500 mb-1">Record Type</label>
+          <label className="block text-xs font-medium text-surface-500 mb-1">Record Type</label>
           <select
             value={entityType}
             onChange={(e) => setEntityType(e.target.value)}
-            className="block w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
+            className="block w-full px-3 py-1.5 text-sm border border-surface-300 rounded focus:ring-blue-500 focus:border-blue-500"
           >
             {ENTITY_TYPE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -108,11 +108,11 @@ export function AuditLogViewer({ petId }: AuditLogViewerProps) {
         </div>
 
         <div>
-          <label className="block text-xs font-medium text-gray-500 mb-1">Action</label>
+          <label className="block text-xs font-medium text-surface-500 mb-1">Action</label>
           <select
             value={action}
             onChange={(e) => setAction(e.target.value)}
-            className="block w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
+            className="block w-full px-3 py-1.5 text-sm border border-surface-300 rounded focus:ring-blue-500 focus:border-blue-500"
           >
             {ACTION_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -124,7 +124,7 @@ export function AuditLogViewer({ petId }: AuditLogViewerProps) {
 
         <div className="flex-1" />
 
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-surface-500">
           {total} total {total === 1 ? 'entry' : 'entries'}
         </div>
       </div>
@@ -132,21 +132,21 @@ export function AuditLogViewer({ petId }: AuditLogViewerProps) {
       {/* Log entries */}
       {isLoading && logs.length === 0 ? (
         <div className="flex items-center justify-center py-12">
-          <svg className="animate-spin h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24">
+          <svg className="animate-spin h-8 w-8 text-info" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>
         </div>
       ) : logs.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <div className="text-center py-12 text-surface-500">
+          <svg className="mx-auto h-12 w-12 text-surface-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
           <p className="mt-2">No changes recorded yet</p>
           <p className="text-sm mt-1">Changes to your pet's records will appear here</p>
         </div>
       ) : (
-        <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+        <div className="bg-white rounded-lg border border-surface-200 divide-y divide-surface-100">
           {logs.map((entry) => (
             <AuditLogEntry key={entry.id} entry={entry} />
           ))}
@@ -159,7 +159,7 @@ export function AuditLogViewer({ petId }: AuditLogViewerProps) {
           <button
             onClick={loadMore}
             disabled={isLoading}
-            className="px-4 py-2 text-sm text-blue-600 hover:text-blue-700 disabled:opacity-50"
+            className="px-4 py-2 text-sm text-info hover:text-info disabled:opacity-50"
           >
             {isLoading ? 'Loading...' : 'Load more'}
           </button>

--- a/frontend/src/components/document-import/DocumentExtractionReview.tsx
+++ b/frontend/src/components/document-import/DocumentExtractionReview.tsx
@@ -278,7 +278,7 @@ export function DocumentExtractionReview({
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <svg className="animate-spin h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin h-8 w-8 text-info" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
         </svg>
@@ -288,9 +288,9 @@ export function DocumentExtractionReview({
 
   if (error && !extraction) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-        <p className="text-red-600">{error}</p>
-        <button onClick={onBack} className="mt-2 text-sm text-red-600 hover:text-red-700 underline">
+      <div className="bg-danger-light border border-danger-light rounded-lg p-4">
+        <p className="text-danger">{error}</p>
+        <button onClick={onBack} className="mt-2 text-sm text-danger hover:text-danger underline">
           Go back
         </button>
       </div>
@@ -300,11 +300,11 @@ export function DocumentExtractionReview({
   if (!extraction || extraction.items.length === 0) {
     return (
       <div className="text-center py-8">
-        <p className="text-gray-500">No data was extracted from this document.</p>
-        <p className="text-sm text-gray-400 mt-1">
+        <p className="text-surface-500">No data was extracted from this document.</p>
+        <p className="text-sm text-surface-400 mt-1">
           Try uploading a clearer document or a different file format.
         </p>
-        <button onClick={onBack} className="mt-4 text-blue-600 hover:text-blue-700">
+        <button onClick={onBack} className="mt-4 text-info hover:text-info">
           Go back
         </button>
       </div>
@@ -330,35 +330,35 @@ export function DocumentExtractionReview({
         <div>
           <button
             onClick={onBack}
-            className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+            className="text-sm text-surface-500 hover:text-surface-700 flex items-center gap-1"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             Back to uploads
           </button>
-          <h3 className="mt-2 text-lg font-medium text-gray-900">
+          <h3 className="mt-2 text-lg font-medium text-navy">
             Review Extracted Data
           </h3>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-surface-500">
             From: {upload.original_filename}
           </p>
         </div>
       </div>
 
       {/* Confidence legend */}
-      <div className="bg-gray-50 rounded-lg p-3 flex items-center gap-4 text-xs">
-        <span className="text-gray-500">Confidence:</span>
+      <div className="bg-surface rounded-lg p-3 flex items-center gap-4 text-xs">
+        <span className="text-surface-500">Confidence:</span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-green-500"></span>
+          <span className="w-3 h-3 rounded bg-success"></span>
           High (80%+)
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-yellow-500"></span>
+          <span className="w-3 h-3 rounded bg-warning"></span>
           Medium (50-80%)
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-red-500"></span>
+          <span className="w-3 h-3 rounded bg-danger"></span>
           Low (&lt;50%)
         </span>
         <span className="flex items-center gap-1">
@@ -368,8 +368,8 @@ export function DocumentExtractionReview({
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-lg p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
 
@@ -377,15 +377,15 @@ export function DocumentExtractionReview({
       {pendingItems.length > 0 && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h4 className="font-medium text-gray-900">
+            <h4 className="font-medium text-navy">
               Items to Review ({pendingItems.length})
             </h4>
             <div className="flex items-center gap-2 text-sm">
-              <button onClick={selectAll} className="text-blue-600 hover:text-blue-700">
+              <button onClick={selectAll} className="text-info hover:text-info">
                 Select all
               </button>
-              <span className="text-gray-300">|</span>
-              <button onClick={selectNone} className="text-blue-600 hover:text-blue-700">
+              <span className="text-surface-300">|</span>
+              <button onClick={selectNone} className="text-info hover:text-info">
                 Select none
               </button>
             </div>
@@ -420,7 +420,7 @@ export function DocumentExtractionReview({
             <button
               onClick={handleApprove}
               disabled={totalReadyCount === 0 || isApproving}
-              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 bg-success text-white rounded-md hover:bg-success disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isApproving ? (
                 <>
@@ -443,7 +443,7 @@ export function DocumentExtractionReview({
             <button
               onClick={handleReject}
               disabled={selectedIds.size === 0 || isRejecting}
-              className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 bg-danger text-white rounded-md hover:bg-danger disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isRejecting ? 'Rejecting...' : `Reject Selected (${selectedIds.size})`}
             </button>
@@ -454,7 +454,7 @@ export function DocumentExtractionReview({
       {/* Processed items */}
       {processedItems.length > 0 && (
         <div className="mt-8">
-          <h4 className="font-medium text-gray-900 mb-3">
+          <h4 className="font-medium text-navy mb-3">
             Already Processed ({processedItems.length})
           </h4>
           <div className="space-y-3 opacity-75">
@@ -474,17 +474,17 @@ export function DocumentExtractionReview({
 
       {/* All done */}
       {pendingItems.length === 0 && processedItems.length > 0 && (
-        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
-          <svg className="mx-auto h-12 w-12 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <div className="bg-success-light border border-success-light rounded-lg p-4 text-center">
+          <svg className="mx-auto h-12 w-12 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
-          <h3 className="mt-2 text-lg font-medium text-green-900">All items processed!</h3>
-          <p className="text-sm text-green-600 mt-1">
+          <h3 className="mt-2 text-lg font-medium text-success">All items processed!</h3>
+          <p className="text-sm text-success mt-1">
             The extracted data has been reviewed and added to your pet's records.
           </p>
           <button
             onClick={onBack}
-            className="mt-4 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+            className="mt-4 px-4 py-2 bg-success text-white rounded-md hover:bg-success"
           >
             Back to uploads
           </button>

--- a/frontend/src/components/document-import/DocumentImportSection.tsx
+++ b/frontend/src/components/document-import/DocumentImportSection.tsx
@@ -294,7 +294,7 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <svg className="animate-spin h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin h-8 w-8 text-info" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
         </svg>
@@ -320,10 +320,10 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
     <div className="space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900" style={{ fontFamily: 'var(--font-heading, inherit)' }}>
+        <h3 className="text-lg font-semibold text-navy" style={{ fontFamily: 'var(--font-heading, inherit)' }}>
           Documents
           {displayItems.length > 0 && (
-            <span className="ml-2 text-sm font-normal text-gray-400">{displayItems.length} total</span>
+            <span className="ml-2 text-sm font-normal text-surface-400">{displayItems.length} total</span>
           )}
         </h3>
         <div className="flex items-center gap-3">
@@ -348,7 +348,7 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
               <button
                 onClick={() => { setViewMode('grid'); try { localStorage.setItem('fc-doc-view-mode', 'grid'); } catch {} }}
                 className={`px-3 py-1.5 text-xs font-medium flex items-center gap-1 transition-colors ${
-                  viewMode === 'grid' ? 'bg-white text-gray-900 shadow-sm' : 'bg-gray-50 text-gray-400 hover:text-gray-600'
+                  viewMode === 'grid' ? 'bg-white text-navy shadow-sm' : 'bg-surface text-surface-400 hover:text-surface-600'
                 }`}
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -359,7 +359,7 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
               <button
                 onClick={() => { setViewMode('list'); try { localStorage.setItem('fc-doc-view-mode', 'list'); } catch {} }}
                 className={`px-3 py-1.5 text-xs font-medium flex items-center gap-1 transition-colors ${
-                  viewMode === 'list' ? 'bg-white text-gray-900 shadow-sm' : 'bg-gray-50 text-gray-400 hover:text-gray-600'
+                  viewMode === 'list' ? 'bg-white text-navy shadow-sm' : 'bg-surface text-surface-400 hover:text-surface-600'
                 }`}
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -374,8 +374,8 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-md p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-md p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
 
@@ -397,7 +397,7 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
                 className={`px-3 py-1 text-xs font-semibold rounded-full border transition-colors ${
                   isActive
                     ? 'text-white border-transparent'
-                    : 'bg-white text-gray-500 hover:text-gray-700'
+                    : 'bg-white text-surface-500 hover:text-surface-700'
                 }`}
                 style={isActive ? {
                   background: 'var(--color-navy, #1B2A4A)',
@@ -423,16 +423,16 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
       {/* Document library */}
       {filteredItems.length === 0 && displayItems.length === 0 && (
         <div className="text-center py-10">
-          <svg className="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <svg className="mx-auto h-12 w-12 text-surface-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
           </svg>
-          <h4 className="mt-2 text-sm font-semibold text-gray-900">No documents yet</h4>
-          <p className="mt-1 text-sm text-gray-500">Upload vet records, prescriptions, or photos to keep them safe and organized.</p>
+          <h4 className="mt-2 text-sm font-semibold text-navy">No documents yet</h4>
+          <p className="mt-1 text-sm text-surface-500">Upload vet records, prescriptions, or photos to keep them safe and organized.</p>
         </div>
       )}
 
       {filteredItems.length === 0 && displayItems.length > 0 && (
-        <p className="text-sm text-gray-500 text-center py-6">No documents match this filter.</p>
+        <p className="text-sm text-surface-500 text-center py-6">No documents match this filter.</p>
       )}
 
       {/* Grid view */}
@@ -491,12 +491,12 @@ export function DocumentImportSection({ petId, onImportComplete, navigateToUploa
 
 // Status helpers
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-  uploaded: { bg: 'bg-gray-100', text: 'text-gray-600' },
-  pending: { bg: 'bg-blue-50', text: 'text-blue-700' },
-  processing: { bg: 'bg-blue-50', text: 'text-blue-700' },
+  uploaded: { bg: 'bg-surface-100', text: 'text-surface-600' },
+  pending: { bg: 'bg-info-light', text: 'text-info' },
+  processing: { bg: 'bg-info-light', text: 'text-info' },
   pending_review: { bg: 'bg-amber-50', text: 'text-amber-700' },
-  completed: { bg: 'bg-green-50', text: 'text-green-700' },
-  failed: { bg: 'bg-red-50', text: 'text-red-700' },
+  completed: { bg: 'bg-success-light', text: 'text-success' },
+  failed: { bg: 'bg-danger-light', text: 'text-danger' },
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -509,12 +509,12 @@ const STATUS_LABELS: Record<string, string> = {
 };
 
 const STATUS_DOT_COLORS: Record<string, string> = {
-  uploaded: 'bg-gray-400',
-  pending: 'bg-blue-400',
-  processing: 'bg-blue-400',
+  uploaded: 'bg-surface-400',
+  pending: 'bg-info',
+  processing: 'bg-info',
   pending_review: 'bg-amber-400',
-  completed: 'bg-green-500',
-  failed: 'bg-red-500',
+  completed: 'bg-success',
+  failed: 'bg-danger',
 };
 
 // Delete confirmation dialog
@@ -541,8 +541,8 @@ function DeleteConfirmDialog({
         className="bg-white rounded-lg shadow-xl max-w-sm w-full p-5"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-base font-semibold text-gray-900 mb-1">Delete document?</h3>
-        <p className="text-sm text-gray-500 mb-4 break-words">
+        <h3 className="text-base font-semibold text-navy mb-1">Delete document?</h3>
+        <p className="text-sm text-surface-500 mb-4 break-words">
           {isProcessed
             ? `"${name}" has imported health records. What should happen to them?`
             : `Are you sure you want to delete "${name}"? This cannot be undone.`}
@@ -572,7 +572,7 @@ function DeleteConfirmDialog({
             <button
               onClick={onCancel}
               disabled={isDeleting}
-              className="w-full px-4 py-2 text-sm text-gray-500 hover:text-gray-700 transition-colors disabled:opacity-50"
+              className="w-full px-4 py-2 text-sm text-surface-500 hover:text-surface-700 transition-colors disabled:opacity-50"
             >
               Cancel
             </button>
@@ -582,7 +582,7 @@ function DeleteConfirmDialog({
             <button
               onClick={onCancel}
               disabled={isDeleting}
-              className="px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 transition-colors disabled:opacity-50"
+              className="px-4 py-2 text-sm font-medium text-surface-500 hover:text-surface-700 transition-colors disabled:opacity-50"
             >
               Cancel
             </button>
@@ -676,12 +676,12 @@ function GridCard({
   return (
     <>
       <div
-        className={`group rounded-lg border overflow-hidden bg-white transition-all cursor-pointer hover:border-blue-400 hover:shadow-md hover:-translate-y-0.5`}
+        className={`group rounded-lg border overflow-hidden bg-white transition-all cursor-pointer hover:border-info hover:shadow-md hover:-translate-y-0.5`}
         style={{ borderColor: 'var(--color-surface-200, #E2E5E9)' }}
         onClick={handleClick}
       >
         {/* Thumbnail */}
-        <div className="aspect-square bg-gray-100 relative flex items-center justify-center overflow-hidden">
+        <div className="aspect-square bg-surface-100 relative flex items-center justify-center overflow-hidden">
           {isImage ? (
             <img
               src={getDocumentUrl(upload)}
@@ -690,14 +690,14 @@ function GridCard({
               loading="lazy"
             />
           ) : (
-            <svg className="w-12 h-12 text-red-300" viewBox="0 0 24 24" fill="currentColor">
+            <svg className="w-12 h-12 text-danger" viewBox="0 0 24 24" fill="currentColor">
               <path d="M6 2h8l6 6v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4a2 2 0 012-2z"/>
             </svg>
           )}
 
           {/* Status badge overlay */}
           {isStored && (
-            <span className="absolute top-1.5 right-1.5 text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded bg-white/85 text-gray-500">
+            <span className="absolute top-1.5 right-1.5 text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded bg-white/85 text-surface-500">
               Uploaded
             </span>
           )}
@@ -707,7 +707,7 @@ function GridCard({
             </span>
           )}
           {(isProcessing || isScanning) && (
-            <span className="absolute top-1.5 right-1.5 text-[10px] font-bold px-2 py-0.5 rounded bg-blue-50/90 text-blue-700 animate-pulse">
+            <span className="absolute top-1.5 right-1.5 text-[10px] font-bold px-2 py-0.5 rounded bg-info-light/90 text-info animate-pulse">
               Processing...
             </span>
           )}
@@ -715,7 +715,7 @@ function GridCard({
           {/* Delete button overlay */}
           <button
             onClick={(e) => { e.stopPropagation(); onDelete(); }}
-            className="absolute top-1.5 left-1.5 p-1 rounded bg-white/80 text-gray-400 hover:text-red-500 hover:bg-white transition-colors opacity-0 group-hover:opacity-100"
+            className="absolute top-1.5 left-1.5 p-1 rounded bg-white/80 text-surface-400 hover:text-danger hover:bg-white transition-colors opacity-0 group-hover:opacity-100"
             title="Delete document"
           >
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -742,13 +742,13 @@ function GridCard({
                 onChange={(e) => setRenameTo(e.target.value)}
                 onKeyDown={handleRenameKeyDown}
                 maxLength={255}
-                className="flex-1 min-w-0 text-sm font-semibold text-gray-900 border border-blue-400 rounded px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                className="flex-1 min-w-0 text-sm font-semibold text-navy border border-info rounded px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
                 disabled={renaming}
               />
-              <button onClick={commitRename} disabled={renaming} className="p-0.5 text-green-600 hover:text-green-700 disabled:opacity-50" title="Save">
+              <button onClick={commitRename} disabled={renaming} className="p-0.5 text-success hover:text-success disabled:opacity-50" title="Save">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
               </button>
-              <button onClick={cancelRename} disabled={renaming} className="p-0.5 text-gray-400 hover:text-gray-600 disabled:opacity-50" title="Cancel">
+              <button onClick={cancelRename} disabled={renaming} className="p-0.5 text-surface-400 hover:text-surface-600 disabled:opacity-50" title="Cancel">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
               </button>
             </div>
@@ -756,24 +756,24 @@ function GridCard({
             <div className="flex items-center gap-1">
               <button
                 onClick={startRename}
-                className="flex-shrink-0 p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
+                className="flex-shrink-0 p-0.5 text-surface-400 hover:text-surface-600 transition-colors"
                 title="Rename"
               >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                 </svg>
               </button>
-              <p className="text-xs md:text-sm font-semibold text-gray-900 truncate flex-1 min-w-0">
+              <p className="text-xs md:text-sm font-semibold text-navy truncate flex-1 min-w-0">
                 {item.groupName || upload.original_filename}
               </p>
             </div>
           )}
           <div className="flex items-center gap-1.5 mt-1">
-            <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${STATUS_DOT_COLORS[upload.status] || 'bg-gray-400'}`} />
-            <span className="text-[11px] md:text-xs text-gray-500">
+            <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${STATUS_DOT_COLORS[upload.status] || 'bg-surface-400'}`} />
+            <span className="text-[11px] md:text-xs text-surface-500">
               {isScanning ? 'Processing...' : STATUS_LABELS[upload.status] || upload.status}
             </span>
-            <span className="text-[11px] md:text-xs text-gray-400">
+            <span className="text-[11px] md:text-xs text-surface-400">
               {new Date(upload.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
             </span>
           </div>
@@ -896,7 +896,7 @@ function ListCard({
     >
       <div className="flex items-center gap-3 p-3">
         {/* Thumbnail */}
-        <div className="w-11 h-11 rounded-md overflow-hidden flex-shrink-0 bg-gray-100 flex items-center justify-center">
+        <div className="w-11 h-11 rounded-md overflow-hidden flex-shrink-0 bg-surface-100 flex items-center justify-center">
           {isImage ? (
             <img
               src={getDocumentUrl(upload)}
@@ -905,7 +905,7 @@ function ListCard({
               loading="lazy"
             />
           ) : (
-            <svg className="w-6 h-6 text-red-300" viewBox="0 0 24 24" fill="currentColor">
+            <svg className="w-6 h-6 text-danger" viewBox="0 0 24 24" fill="currentColor">
               <path d="M6 2h8l6 6v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4a2 2 0 012-2z"/>
             </svg>
           )}
@@ -922,13 +922,13 @@ function ListCard({
                 onChange={(e) => setRenameTo(e.target.value)}
                 onKeyDown={handleRenameKeyDown}
                 maxLength={255}
-                className="flex-1 min-w-0 text-sm font-semibold text-gray-900 border border-blue-400 rounded px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                className="flex-1 min-w-0 text-sm font-semibold text-navy border border-info rounded px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-400"
                 disabled={renaming}
               />
-              <button onClick={commitRename} disabled={renaming} className="p-0.5 text-green-600 hover:text-green-700 disabled:opacity-50 flex-shrink-0" title="Save">
+              <button onClick={commitRename} disabled={renaming} className="p-0.5 text-success hover:text-success disabled:opacity-50 flex-shrink-0" title="Save">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
               </button>
-              <button onClick={cancelRename} disabled={renaming} className="p-0.5 text-gray-400 hover:text-gray-600 disabled:opacity-50 flex-shrink-0" title="Cancel">
+              <button onClick={cancelRename} disabled={renaming} className="p-0.5 text-surface-400 hover:text-surface-600 disabled:opacity-50 flex-shrink-0" title="Cancel">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
               </button>
             </div>
@@ -936,7 +936,7 @@ function ListCard({
             <div className="flex items-center gap-1">
               <button
                 onClick={startRename}
-                className="flex-shrink-0 p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
+                className="flex-shrink-0 p-0.5 text-surface-400 hover:text-surface-600 transition-colors"
                 title="Rename"
               >
                 <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -945,7 +945,7 @@ function ListCard({
               </button>
               {/* For standalone docs: link to file. For groups: just a label */}
               {isGroup ? (
-                <span className="text-sm font-semibold text-gray-900 truncate flex-1 min-w-0">
+                <span className="text-sm font-semibold text-navy truncate flex-1 min-w-0">
                   {item.groupName || upload.original_filename}
                 </span>
               ) : (
@@ -953,7 +953,7 @@ function ListCard({
                   href={getDocumentUrl(upload)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm font-semibold text-gray-900 truncate flex-1 min-w-0 hover:text-blue-700 hover:underline"
+                  className="text-sm font-semibold text-navy truncate flex-1 min-w-0 hover:text-info hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {upload.original_filename}
@@ -962,18 +962,18 @@ function ListCard({
             </div>
           )}
           <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-            <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${STATUS_COLORS[upload.status]?.bg || 'bg-gray-100'} ${STATUS_COLORS[upload.status]?.text || 'text-gray-600'} ${(isProcessing || isScanning) ? 'animate-pulse' : ''}`}>
+            <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${STATUS_COLORS[upload.status]?.bg || 'bg-surface-100'} ${STATUS_COLORS[upload.status]?.text || 'text-surface-600'} ${(isProcessing || isScanning) ? 'animate-pulse' : ''}`}>
               {isScanning ? 'Processing...' : upload.status === 'pending_review' && upload.pending_items
                 ? `${upload.pending_items} pending`
                 : STATUS_LABELS[upload.status] || upload.status}
             </span>
             {isGroup && (
-              <span className="text-[11px] text-gray-400">{item.pages.length} pages</span>
+              <span className="text-[11px] text-surface-400">{item.pages.length} pages</span>
             )}
             {upload.user_tag && (
-              <span className="text-[11px] text-gray-400">{upload.user_tag}</span>
+              <span className="text-[11px] text-surface-400">{upload.user_tag}</span>
             )}
-            <span className="text-[11px] text-gray-400">
+            <span className="text-[11px] text-surface-400">
               {new Date(upload.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
             </span>
           </div>
@@ -984,7 +984,7 @@ function ListCard({
           {isGroup && (
             <button
               onClick={() => setPagesExpanded(!pagesExpanded)}
-              className="text-xs font-semibold px-3 py-1.5 rounded-md border text-gray-500 hover:bg-gray-50 transition-colors"
+              className="text-xs font-semibold px-3 py-1.5 rounded-md border text-surface-500 hover:bg-surface transition-colors"
               style={{ borderColor: 'var(--color-surface-200, #E2E5E9)' }}
             >
               {pagesExpanded ? 'Hide Pages' : 'View Pages'}
@@ -1020,7 +1020,7 @@ function ListCard({
           {canView && (
             <button
               onClick={onSelect}
-              className="text-xs font-semibold px-3 py-1.5 rounded-md border text-gray-500 hover:bg-gray-50 transition-colors"
+              className="text-xs font-semibold px-3 py-1.5 rounded-md border text-surface-500 hover:bg-surface transition-colors"
               style={{ borderColor: 'var(--color-surface-200, #E2E5E9)' }}
             >
               View
@@ -1029,7 +1029,7 @@ function ListCard({
           {/* Delete button */}
           <button
             onClick={onDelete}
-            className="p-1.5 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+            className="p-1.5 rounded text-surface-400 hover:text-danger hover:bg-danger-light transition-colors"
             title="Delete document"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -1047,7 +1047,7 @@ function ListCard({
               <div key={page.id} className="flex-shrink-0 flex flex-col items-center" style={{ width: '100px' }}>
                 {/* Thumbnail — click to view */}
                 <div
-                  className="w-full bg-gray-100 cursor-pointer relative rounded-md overflow-hidden border hover:border-blue-400 hover:shadow-md transition-all"
+                  className="w-full bg-surface-100 cursor-pointer relative rounded-md overflow-hidden border hover:border-info hover:shadow-md transition-all"
                   style={{ height: '80px', borderColor: 'var(--color-surface-200, #E2E5E9)' }}
                   onClick={() => setLightboxPage(page)}
                 >
@@ -1067,18 +1067,18 @@ function ListCard({
                   <button
                     onClick={() => handleMovePage(idx, idx - 1)}
                     disabled={idx === 0}
-                    className="p-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                    className="p-0.5 rounded text-surface-400 hover:text-surface-700 hover:bg-surface-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-surface-400"
                     title="Move left"
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
                     </svg>
                   </button>
-                  <span className="text-[10px] text-gray-400 tabular-nums">{idx + 1}/{item.pages.length}</span>
+                  <span className="text-[10px] text-surface-400 tabular-nums">{idx + 1}/{item.pages.length}</span>
                   <button
                     onClick={() => handleMovePage(idx, idx + 1)}
                     disabled={idx === item.pages.length - 1}
-                    className="p-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                    className="p-0.5 rounded text-surface-400 hover:text-surface-700 hover:bg-surface-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-surface-400"
                     title="Move right"
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -1093,7 +1093,7 @@ function ListCard({
               <div className="flex-shrink-0">
                 <button
                   onClick={onAddPage}
-                  className="rounded-md border-2 border-dashed flex flex-col items-center justify-center text-gray-300 hover:border-blue-400 hover:text-blue-500 transition-colors"
+                  className="rounded-md border-2 border-dashed flex flex-col items-center justify-center text-surface-300 hover:border-info hover:text-info transition-colors"
                   style={{ borderColor: 'var(--color-surface-300, #CED4DA)', width: '100px', height: '80px' }}
                 >
                   <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path d="M12 4v16m8-8H4"/></svg>
@@ -1102,7 +1102,7 @@ function ListCard({
               </div>
             )}
           </div>
-          <p className="text-[10px] text-gray-400 mt-1.5">Use arrows to reorder &middot; Click to view full size</p>
+          <p className="text-[10px] text-surface-400 mt-1.5">Use arrows to reorder &middot; Click to view full size</p>
         </div>
       )}
 
@@ -1123,7 +1123,7 @@ function ListCard({
         <div className="px-3 pb-3">
           <button
             onClick={() => setMetadataExpanded(!metadataExpanded)}
-            className="text-[11px] text-gray-400 hover:text-gray-600 flex items-center gap-1"
+            className="text-[11px] text-surface-400 hover:text-surface-600 flex items-center gap-1"
           >
             <svg className={`h-3 w-3 transition-transform ${metadataExpanded ? 'rotate-90' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -1176,53 +1176,53 @@ function PageLightbox({
         className="relative bg-white rounded-lg max-w-3xl w-full max-h-[90vh] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
-        <button onClick={onClose} className="absolute top-3 right-3 z-10 bg-white/90 rounded-full p-1.5 text-gray-600 hover:text-gray-900 shadow-sm">
+        <button onClick={onClose} className="absolute top-3 right-3 z-10 bg-white/90 rounded-full p-1.5 text-surface-600 hover:text-navy shadow-sm">
           <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
         </button>
 
         {pages.length > 1 && (
           <>
             {currentIdx > 0 && (
-              <button onClick={() => onNavigate(pages[currentIdx - 1])} className="absolute left-3 top-1/2 -translate-y-1/2 z-10 bg-white/90 rounded-full p-2 text-gray-600 hover:text-gray-900 shadow-md">
+              <button onClick={() => onNavigate(pages[currentIdx - 1])} className="absolute left-3 top-1/2 -translate-y-1/2 z-10 bg-white/90 rounded-full p-2 text-surface-600 hover:text-navy shadow-md">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
               </button>
             )}
             {currentIdx < pages.length - 1 && (
-              <button onClick={() => onNavigate(pages[currentIdx + 1])} className="absolute right-3 top-1/2 -translate-y-1/2 z-10 bg-white/90 rounded-full p-2 text-gray-600 hover:text-gray-900 shadow-md">
+              <button onClick={() => onNavigate(pages[currentIdx + 1])} className="absolute right-3 top-1/2 -translate-y-1/2 z-10 bg-white/90 rounded-full p-2 text-surface-600 hover:text-navy shadow-md">
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
               </button>
             )}
           </>
         )}
 
-        <div className="flex items-center justify-center bg-gray-900 max-h-[75vh]">
+        <div className="flex items-center justify-center bg-navy max-h-[75vh]">
           <img src={getDocumentUrl(currentPage)} alt={currentPage.original_filename} className="max-w-full max-h-[75vh] object-contain" />
         </div>
 
         <div className="p-3 border-t flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <span className="text-sm font-medium text-gray-700">
+            <span className="text-sm font-medium text-surface-700">
               {pages.length > 1 ? `Page ${currentIdx + 1} of ${pages.length}` : currentPage.original_filename}
             </span>
             {pages.length > 1 && (
               <>
-                <span className="text-xs text-gray-400">{currentPage.original_filename}</span>
+                <span className="text-xs text-surface-400">{currentPage.original_filename}</span>
                 <div className="flex items-center gap-1 border-l pl-3" style={{ borderColor: 'var(--color-surface-200, #E2E5E9)' }}>
                   <button
                     onClick={() => handleMovePage(currentIdx, currentIdx - 1)}
                     disabled={currentIdx === 0}
-                    className="p-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                    className="p-1 rounded text-surface-400 hover:text-surface-700 hover:bg-surface-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-surface-400"
                     title="Move page earlier"
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
                     </svg>
                   </button>
-                  <span className="text-[11px] text-gray-500 font-medium">Move</span>
+                  <span className="text-[11px] text-surface-500 font-medium">Move</span>
                   <button
                     onClick={() => handleMovePage(currentIdx, currentIdx + 1)}
                     disabled={currentIdx === pages.length - 1}
-                    className="p-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                    className="p-1 rounded text-surface-400 hover:text-surface-700 hover:bg-surface-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-surface-400"
                     title="Move page later"
                   >
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -1233,7 +1233,7 @@ function PageLightbox({
               </>
             )}
           </div>
-          <a href={getDocumentUrl(currentPage)} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 hover:underline">
+          <a href={getDocumentUrl(currentPage)} target="_blank" rel="noopener noreferrer" className="text-sm text-info hover:underline">
             Open full size
           </a>
         </div>
@@ -1273,28 +1273,28 @@ function InlineMetadataForm({ petId, uploadId, upload }: { petId: number; upload
   return (
     <div className="mt-2 space-y-2">
       <div>
-        <label className="block text-[11px] text-gray-500 mb-1">Tag</label>
+        <label className="block text-[11px] text-surface-500 mb-1">Tag</label>
         <div className="flex flex-wrap gap-1 mb-1">
           {tagSuggestions.map(tag => (
-            <button key={tag} onClick={() => setUserTag(tag)} className={`px-2 py-0.5 text-[11px] rounded-full border transition-colors ${userTag === tag ? 'bg-blue-100 border-blue-300 text-blue-700' : 'bg-white border-gray-200 text-gray-500 hover:border-gray-300'}`}>
+            <button key={tag} onClick={() => setUserTag(tag)} className={`px-2 py-0.5 text-[11px] rounded-full border transition-colors ${userTag === tag ? 'bg-info-light border-info text-info' : 'bg-white border-surface-200 text-surface-500 hover:border-surface-300'}`}>
               {tag}
             </button>
           ))}
         </div>
-        <input type="text" value={userTag} onChange={(e) => setUserTag(e.target.value)} placeholder="Custom tag..." className="w-full border border-gray-200 rounded px-2 py-1 text-xs" />
+        <input type="text" value={userTag} onChange={(e) => setUserTag(e.target.value)} placeholder="Custom tag..." className="w-full border border-surface-200 rounded px-2 py-1 text-xs" />
       </div>
       <div>
-        <label className="block text-[11px] text-gray-500 mb-1">Note</label>
-        <input type="text" value={userDescription} onChange={(e) => setUserDescription(e.target.value)} placeholder="Brief description..." className="w-full border border-gray-200 rounded px-2 py-1 text-xs" />
+        <label className="block text-[11px] text-surface-500 mb-1">Note</label>
+        <input type="text" value={userDescription} onChange={(e) => setUserDescription(e.target.value)} placeholder="Brief description..." className="w-full border border-surface-200 rounded px-2 py-1 text-xs" />
       </div>
       <div className="flex gap-2">
         <div className="flex-1">
-          <label className="block text-[11px] text-gray-500 mb-1">Date taken</label>
-          <input type="date" value={dateTaken} onChange={(e) => setDateTaken(e.target.value)} className="w-full border border-gray-200 rounded px-2 py-1 text-xs" />
+          <label className="block text-[11px] text-surface-500 mb-1">Date taken</label>
+          <input type="date" value={dateTaken} onChange={(e) => setDateTaken(e.target.value)} className="w-full border border-surface-200 rounded px-2 py-1 text-xs" />
         </div>
         <div className="flex-1">
-          <label className="block text-[11px] text-gray-500 mb-1">Body area</label>
-          <input type="text" value={bodyArea} onChange={(e) => setBodyArea(e.target.value)} placeholder="e.g., Left hip" className="w-full border border-gray-200 rounded px-2 py-1 text-xs" />
+          <label className="block text-[11px] text-surface-500 mb-1">Body area</label>
+          <input type="text" value={bodyArea} onChange={(e) => setBodyArea(e.target.value)} placeholder="e.g., Left hip" className="w-full border border-surface-200 rounded px-2 py-1 text-xs" />
         </div>
       </div>
       <button onClick={handleSave} disabled={saving} className="px-3 py-1 text-xs font-semibold text-white rounded disabled:opacity-50" style={{ background: 'var(--color-steel, #4A7FB5)' }}>

--- a/frontend/src/components/document-import/DocumentUploadZone.tsx
+++ b/frontend/src/components/document-import/DocumentUploadZone.tsx
@@ -208,19 +208,19 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
     <div className="space-y-4">
       {/* Multi-file grouping dialog */}
       {pendingFiles && (
-        <div className="bg-white border border-gray-200 rounded-lg p-5 shadow-sm">
-          <p className="font-medium text-gray-900 mb-3">
+        <div className="bg-white border border-surface-200 rounded-lg p-5 shadow-sm">
+          <p className="font-medium text-navy mb-3">
             {pendingFiles.length + pendingPdfs.length} files selected
           </p>
 
           {/* PDF info banner */}
           {pendingPdfs.length > 0 && (
-            <div className="mb-4 bg-gray-50 border border-gray-200 rounded-md px-3 py-2.5 flex items-start gap-2.5">
-              <svg className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="currentColor">
+            <div className="mb-4 bg-surface border border-surface-200 rounded-md px-3 py-2.5 flex items-start gap-2.5">
+              <svg className="w-5 h-5 text-danger flex-shrink-0 mt-0.5" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M6 2h8l6 6v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4a2 2 0 012-2z"/>
               </svg>
               <div>
-                <p className="text-sm text-gray-700">
+                <p className="text-sm text-surface-700">
                   {pendingPdfs.length === 1
                     ? <><span className="font-medium">{pendingPdfs[0].name}</span> will upload as a separate document.</>
                     : <><span className="font-medium">{pendingPdfs.length} PDFs</span> will each upload as separate documents.</>
@@ -231,7 +231,7 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
           )}
 
           {/* Image grouping options */}
-          {pendingFiles.length > 1 && <p className="text-xs text-gray-500 mb-2">{pendingFiles.length} images:</p>}
+          {pendingFiles.length > 1 && <p className="text-xs text-surface-500 mb-2">{pendingFiles.length} images:</p>}
 
           {/* Radio options (only when 2+ images — 1 image doesn't need grouping choice) */}
           {pendingFiles.length > 1 && (
@@ -245,10 +245,10 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                   className="mt-0.5"
                 />
                 <div>
-                  <p className="text-sm font-medium text-gray-900">
+                  <p className="text-sm font-medium text-navy">
                     Upload as one document ({pendingFiles.length} pages)
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-surface-500">
                     Combine into a single multi-page document that gets scanned together.
                   </p>
                 </div>
@@ -262,10 +262,10 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                   className="mt-0.5"
                 />
                 <div>
-                  <p className="text-sm font-medium text-gray-900">
+                  <p className="text-sm font-medium text-navy">
                     Upload as {pendingFiles.length} separate documents
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-surface-500">
                     Each file is its own document.
                   </p>
                 </div>
@@ -277,22 +277,22 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
           {groupMode === 'one' && (
             <>
               <div className="mb-4">
-                <label className="block text-sm text-gray-700 mb-1">Document name</label>
+                <label className="block text-sm text-surface-700 mb-1">Document name</label>
                 <input
                   type="text"
                   ref={groupNameRef}
                   placeholder="e.g., Wednesday ER Visit Notes"
-                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full border border-surface-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
                   maxLength={255}
                 />
               </div>
 
               <div className="mb-4">
-                <label className="block text-sm text-gray-700 mb-2">Page order</label>
+                <label className="block text-sm text-surface-700 mb-2">Page order</label>
                 <div className="flex gap-2 overflow-x-auto pb-1">
                   {pendingFiles.map((file, idx) => (
                     <div key={previewUrls[idx]} className="flex-shrink-0 flex flex-col items-center" style={{ width: '88px' }}>
-                      <div className="relative w-20 h-20 rounded-md overflow-hidden bg-gray-100 border border-gray-200">
+                      <div className="relative w-20 h-20 rounded-md overflow-hidden bg-surface-100 border border-surface-200">
                         <img
                           src={previewUrls[idx]}
                           alt={file.name}
@@ -307,19 +307,19 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                           type="button"
                           onClick={() => movePage(idx, idx - 1)}
                           disabled={idx === 0}
-                          className="p-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                          className="p-0.5 rounded text-surface-400 hover:text-surface-700 hover:bg-surface-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-surface-400"
                           title="Move left"
                         >
                           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
                           </svg>
                         </button>
-                        <span className="text-[10px] text-gray-400 tabular-nums">{idx + 1}/{pendingFiles.length}</span>
+                        <span className="text-[10px] text-surface-400 tabular-nums">{idx + 1}/{pendingFiles.length}</span>
                         <button
                           type="button"
                           onClick={() => movePage(idx, idx + 1)}
                           disabled={idx === pendingFiles.length - 1}
-                          className="p-0.5 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                          className="p-0.5 rounded text-surface-400 hover:text-surface-700 hover:bg-surface-100 disabled:opacity-25 disabled:hover:bg-transparent disabled:hover:text-surface-400"
                           title="Move right"
                         >
                           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -338,7 +338,7 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
           {groupMode === 'separate' && (
             <div className="flex flex-wrap gap-2 mb-4">
               {pendingFiles.slice(0, 8).map((file, i) => (
-                <div key={i} className="w-12 h-12 rounded bg-gray-100 flex items-center justify-center text-xs text-gray-500 overflow-hidden">
+                <div key={i} className="w-12 h-12 rounded bg-surface-100 flex items-center justify-center text-xs text-surface-500 overflow-hidden">
                   <img
                     src={previewUrls[i]}
                     alt={file.name}
@@ -347,7 +347,7 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                 </div>
               ))}
               {pendingFiles.length > 8 && (
-                <div className="w-12 h-12 rounded bg-gray-100 flex items-center justify-center text-xs text-gray-500">
+                <div className="w-12 h-12 rounded bg-surface-100 flex items-center justify-center text-xs text-surface-500">
                   +{pendingFiles.length - 8}
                 </div>
               )}
@@ -357,13 +357,13 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
           <div className="flex justify-end gap-2">
             <button
               onClick={handleGroupCancel}
-              className="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              className="px-4 py-2 text-sm text-surface-700 bg-white border border-surface-300 rounded-md hover:bg-surface"
             >
               Cancel
             </button>
             <button
               onClick={handleGroupConfirm}
-              className="px-4 py-2 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700"
+              className="px-4 py-2 text-sm text-white bg-info rounded-md hover:bg-info"
             >
               Upload
             </button>
@@ -379,27 +379,27 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
           onDrop={handleDrop}
           className={`
             border-2 border-dashed rounded-lg p-8 text-center transition-colors duration-200
-            ${isDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-gray-400'}
+            ${isDragOver ? 'border-info bg-info-light' : 'border-surface-300 hover:border-surface-400'}
             ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
           `}
         >
           {isUploading ? (
             <div className="flex flex-col items-center">
-              <svg className="animate-spin h-10 w-10 text-blue-500 mb-3" fill="none" viewBox="0 0 24 24">
+              <svg className="animate-spin h-10 w-10 text-info mb-3" fill="none" viewBox="0 0 24 24">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
               </svg>
-              <p className="text-gray-600">Uploading...</p>
-              <div className="w-48 h-2 bg-gray-200 rounded-full mt-2">
+              <p className="text-surface-600">Uploading...</p>
+              <div className="w-48 h-2 bg-surface-200 rounded-full mt-2">
                 <div
-                  className="h-full bg-blue-500 rounded-full transition-all duration-200"
+                  className="h-full bg-info rounded-full transition-all duration-200"
                   style={{ width: `${uploadProgress}%` }}
                 />
               </div>
             </div>
           ) : (
             <>
-              <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+              <svg className="mx-auto h-12 w-12 text-surface-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
                 <path
                   d="M28 8H12a4 4 0 00-4 4v20m0 0v4a4 4 0 004 4h24a4 4 0 004-4V24M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4-4m4-12h8m-4-4v8"
                   strokeWidth="2"
@@ -407,8 +407,8 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                   strokeLinejoin="round"
                 />
               </svg>
-              <p className="mt-2 text-sm text-gray-600">
-                <label className={`text-blue-600 hover:text-blue-500 ${isDisabled ? '' : 'cursor-pointer'}`}>
+              <p className="mt-2 text-sm text-surface-600">
+                <label className={`text-info hover:text-info ${isDisabled ? '' : 'cursor-pointer'}`}>
                   <span>Upload documents</span>
                   <input
                     ref={fileInputRef}
@@ -422,7 +422,7 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
                 </label>
                 {' '}or drag and drop
               </p>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-surface-500">
                 PDFs and images (JPEG, PNG, WebP, GIF, HEIC, TIFF, BMP) — images are compressed automatically
               </p>
             </>
@@ -431,8 +431,8 @@ export function DocumentUploadZone({ petId, onUploadComplete, disabled }: Docume
       )}
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-md p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-md p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
     </div>

--- a/frontend/src/components/document-import/ImageReviewForm.tsx
+++ b/frontend/src/components/document-import/ImageReviewForm.tsx
@@ -100,17 +100,17 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-medium text-gray-900">Review Image</h3>
+        <h3 className="text-lg font-medium text-navy">Review Image</h3>
         <button
           onClick={onCancel}
-          className="text-sm text-gray-500 hover:text-gray-700"
+          className="text-sm text-surface-500 hover:text-surface-700"
         >
           Back to uploads
         </button>
       </div>
 
       {/* Image preview */}
-      <div className="bg-gray-100 rounded-lg p-4 flex justify-center">
+      <div className="bg-surface-100 rounded-lg p-4 flex justify-center">
         <img
           src={imageUrl}
           alt={upload.original_filename}
@@ -118,7 +118,7 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
         />
       </div>
 
-      <p className="text-sm text-gray-500 text-center">{upload.original_filename}</p>
+      <p className="text-sm text-surface-500 text-center">{upload.original_filename}</p>
 
       {/* Scan for records button — shown for images that haven't been processed */}
       {onScanComplete && (
@@ -155,8 +155,8 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
       <div className="space-y-4">
         {/* Tag (required) */}
         <div>
-          <label htmlFor="image-tag" className="block text-sm font-medium text-gray-700 mb-1">
-            Tag <span className="text-red-500">*</span>
+          <label htmlFor="image-tag" className="block text-sm font-medium text-surface-700 mb-1">
+            Tag <span className="text-danger">*</span>
           </label>
           <input
             id="image-tag"
@@ -165,7 +165,7 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
             value={tag}
             onChange={(e) => setTag(e.target.value)}
             placeholder="e.g. X-ray, Wound photo, Lab result"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
+            className="w-full px-3 py-2 border border-surface-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
             maxLength={100}
           />
           <datalist id="tag-suggestions">
@@ -177,7 +177,7 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
 
         {/* Description (optional) */}
         <div>
-          <label htmlFor="image-description" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="image-description" className="block text-sm font-medium text-surface-700 mb-1">
             Description
           </label>
           <textarea
@@ -186,13 +186,13 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Optional notes about this image"
             rows={3}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
+            className="w-full px-3 py-2 border border-surface-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
           />
         </div>
 
         {/* Date taken */}
         <div>
-          <label htmlFor="image-date-taken" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="image-date-taken" className="block text-sm font-medium text-surface-700 mb-1">
             Date Taken
           </label>
           <input
@@ -200,16 +200,16 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
             type="date"
             value={dateTaken}
             onChange={(e) => setDateTaken(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
+            className="w-full px-3 py-2 border border-surface-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
           />
           {exifDateTaken && !upload.date_taken && (
-            <p className="text-xs text-gray-400 mt-1">Pre-filled from image EXIF data</p>
+            <p className="text-xs text-surface-400 mt-1">Pre-filled from image EXIF data</p>
           )}
         </div>
 
         {/* Body area (optional) */}
         <div>
-          <label htmlFor="image-body-area" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="image-body-area" className="block text-sm font-medium text-surface-700 mb-1">
             Body Area
           </label>
           <input
@@ -218,15 +218,15 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
             value={bodyArea}
             onChange={(e) => setBodyArea(e.target.value)}
             placeholder='e.g. "Left hind leg", "Teeth", "Abdomen"'
-            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
+            className="w-full px-3 py-2 border border-surface-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
             maxLength={100}
           />
         </div>
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-md p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-md p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
 
@@ -235,14 +235,14 @@ export function ImageReviewForm({ petId, upload, exifDateTaken, onSave, onCancel
         <button
           onClick={handleSave}
           disabled={isSaving || !tag.trim()}
-          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 bg-info text-white py-2 px-4 rounded-md text-sm font-medium hover:bg-info disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isSaving ? 'Saving...' : 'Save'}
         </button>
         <button
           onClick={onCancel}
           disabled={isSaving}
-          className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          className="px-4 py-2 border border-surface-300 rounded-md text-sm font-medium text-surface-700 hover:bg-surface disabled:opacity-50"
         >
           Cancel
         </button>

--- a/frontend/src/components/homepage/Features.tsx
+++ b/frontend/src/components/homepage/Features.tsx
@@ -43,7 +43,7 @@ const ICONS: Record<string, string> = {
 function FeatureIcon({ icon }: { icon: string }) {
   const path = ICONS[icon] || ICONS.sparkles;
   return (
-    <svg className="w-8 h-8" style={{ color: 'var(--color-steel)' }} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-8 h-8" style={{ color: 'var(--color-coral)' }} fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={path} />
     </svg>
   );
@@ -51,10 +51,10 @@ function FeatureIcon({ icon }: { icon: string }) {
 
 function FeatureCard({ feature }: { feature: FeatureItem }) {
   return (
-    <div className="card">
+    <div className="card-interactive">
       <div
         className="flex items-center justify-center mb-4"
-        style={{ width: '56px', height: '56px', borderRadius: 'var(--radius-lg)', background: 'var(--color-steel-light)' }}
+        style={{ width: '56px', height: '56px', borderRadius: 'var(--radius-lg)', background: 'var(--color-warm-bg)' }}
       >
         <FeatureIcon icon={feature.icon} />
       </div>

--- a/frontend/src/components/homepage/Hero.tsx
+++ b/frontend/src/components/homepage/Hero.tsx
@@ -13,7 +13,7 @@ export default function Hero({ content }: HeroProps) {
   return (
     <section
       className="relative min-h-screen flex items-center pt-16 md:pt-20"
-      style={{ background: 'linear-gradient(180deg, var(--color-navy-50) 0%, var(--color-white) 40%)' }}
+      style={{ background: 'linear-gradient(180deg, var(--color-warm-bg) 0%, var(--color-white) 50%)' }}
     >
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 md:py-20">
         <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">

--- a/frontend/src/components/homepage/HowItWorks.tsx
+++ b/frontend/src/components/homepage/HowItWorks.tsx
@@ -11,7 +11,7 @@ function StepCard({ step, isLast }: { step: HowItWorksStep; isLast: boolean }) {
         className="flex items-center justify-center text-xl font-bold mb-4 relative z-10"
         style={{
           width: '56px', height: '56px', borderRadius: '50%',
-          background: 'var(--color-navy)', color: 'white',
+          background: 'var(--color-coral)', color: 'white',
           fontFamily: 'var(--font-heading)',
         }}
       >
@@ -32,7 +32,7 @@ function StepCard({ step, isLast }: { step: HowItWorksStep; isLast: boolean }) {
             left: 'calc(50% + 28px)',
             width: 'calc(100% - 56px)',
             height: '2px',
-            background: 'var(--color-navy-50)',
+            background: 'var(--color-coral-light)',
           }}
         />
       )}
@@ -48,7 +48,7 @@ function StepCardMobile({ step, isLast }: { step: HowItWorksStep; isLast: boolea
           className="flex items-center justify-center text-lg font-bold relative z-10"
           style={{
             width: '48px', height: '48px', borderRadius: '50%',
-            background: 'var(--color-navy)', color: 'white',
+            background: 'var(--color-coral)', color: 'white',
             fontFamily: 'var(--font-heading)',
           }}
         >
@@ -57,7 +57,7 @@ function StepCardMobile({ step, isLast }: { step: HowItWorksStep; isLast: boolea
         {!isLast && (
           <div
             className="absolute left-6 -translate-x-1/2"
-            style={{ top: '48px', width: '2px', height: 'calc(100% - 48px)', background: 'var(--color-navy-50)' }}
+            style={{ top: '48px', width: '2px', height: 'calc(100% - 48px)', background: 'var(--color-coral-light)' }}
           />
         )}
       </div>

--- a/frontend/src/components/pdf-import/ConfidenceBadge.tsx
+++ b/frontend/src/components/pdf-import/ConfidenceBadge.tsx
@@ -5,7 +5,7 @@ interface ConfidenceBadgeProps {
 export function ConfidenceBadge({ score }: ConfidenceBadgeProps) {
   if (score === null) {
     return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-100 text-surface-600">
         Unknown
       </span>
     );
@@ -18,13 +18,13 @@ export function ConfidenceBadge({ score }: ConfidenceBadgeProps) {
   let label: string;
 
   if (score >= 0.8) {
-    colorClass = 'bg-green-100 text-green-800';
+    colorClass = 'bg-success-light text-success';
     label = 'High';
   } else if (score >= 0.5) {
-    colorClass = 'bg-yellow-100 text-yellow-800';
+    colorClass = 'bg-warning-light text-warning-dark';
     label = 'Medium';
   } else {
-    colorClass = 'bg-red-100 text-red-800';
+    colorClass = 'bg-danger-light text-danger';
     label = 'Low';
   }
 

--- a/frontend/src/components/pdf-import/ExtractionItemCard.tsx
+++ b/frontend/src/components/pdf-import/ExtractionItemCard.tsx
@@ -32,10 +32,10 @@ const RECORD_TYPE_CONFIG: Record<RecordType, { label: string; icon: string }> = 
 
 function getConfidenceColor(score: number | null, isDuplicate: boolean): string {
   if (isDuplicate) return 'bg-amber-50 border-amber-300';
-  if (score === null) return 'bg-gray-50 border-gray-200';
-  if (score >= 0.8) return 'bg-green-50 border-green-200';
-  if (score >= 0.5) return 'bg-yellow-50 border-yellow-200';
-  return 'bg-red-50 border-red-200';
+  if (score === null) return 'bg-surface border-surface-200';
+  if (score >= 0.8) return 'bg-success-light border-success-light';
+  if (score >= 0.5) return 'bg-warning-light border-warning-light';
+  return 'bg-danger-light border-danger-light';
 }
 
 const SEVERITY_OPTIONS = [
@@ -197,11 +197,11 @@ export function ExtractionItemCard({
   const statusBadge = () => {
     switch (item.status) {
       case 'approved':
-        return <span className="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">Approved</span>;
+        return <span className="text-xs bg-success-light text-success px-2 py-0.5 rounded">Approved</span>;
       case 'rejected':
-        return <span className="text-xs bg-red-100 text-red-800 px-2 py-0.5 rounded">Rejected</span>;
+        return <span className="text-xs bg-danger-light text-danger px-2 py-0.5 rounded">Rejected</span>;
       case 'modified':
-        return <span className="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded">Modified</span>;
+        return <span className="text-xs bg-info-light text-info px-2 py-0.5 rounded">Modified</span>;
       default:
         return null;
     }
@@ -241,8 +241,8 @@ export function ExtractionItemCard({
 
   /** Get match score badge color */
   const getMatchScoreBadgeColor = (score: number): string => {
-    if (score > 0.9) return 'bg-green-100 text-green-800';
-    if (score >= 0.7) return 'bg-yellow-100 text-yellow-800';
+    if (score > 0.9) return 'bg-success-light text-success';
+    if (score >= 0.7) return 'bg-warning-light text-warning-dark';
     return 'bg-orange-100 text-orange-800';
   };
 
@@ -291,11 +291,11 @@ export function ExtractionItemCard({
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="border-b border-amber-200">
-              <th className="text-left py-2 px-2 text-gray-600 font-medium w-1/4">Field</th>
-              <th className="text-left py-2 px-2 text-gray-600 font-medium w-5/16">Existing</th>
-              <th className="text-left py-2 px-2 text-gray-600 font-medium w-5/16">Imported</th>
+              <th className="text-left py-2 px-2 text-surface-600 font-medium w-1/4">Field</th>
+              <th className="text-left py-2 px-2 text-surface-600 font-medium w-5/16">Existing</th>
+              <th className="text-left py-2 px-2 text-surface-600 font-medium w-5/16">Imported</th>
               {onFieldOverrideChange && mergeAction === 'smart_merge' && (
-                <th className="text-center py-2 px-2 text-gray-600 font-medium w-3/16">Keep</th>
+                <th className="text-center py-2 px-2 text-surface-600 font-medium w-3/16">Keep</th>
               )}
             </tr>
           </thead>
@@ -309,12 +309,12 @@ export function ExtractionItemCard({
               const currentOverride = fieldOverrides?.[field];
 
               return (
-                <tr key={field} className={`border-b border-gray-100 ${hasChange ? 'bg-amber-50/50' : ''}`}>
-                  <td className="py-2 px-2 text-gray-700 font-medium">{label}</td>
-                  <td className={`py-2 px-2 ${hasChange ? 'text-red-700' : 'text-gray-600'}`}>
+                <tr key={field} className={`border-b border-surface-100 ${hasChange ? 'bg-amber-50/50' : ''}`}>
+                  <td className="py-2 px-2 text-surface-700 font-medium">{label}</td>
+                  <td className={`py-2 px-2 ${hasChange ? 'text-danger' : 'text-surface-600'}`}>
                     {existingStr}
                   </td>
-                  <td className={`py-2 px-2 ${hasChange ? 'text-green-700 font-medium' : 'text-gray-600'}`}>
+                  <td className={`py-2 px-2 ${hasChange ? 'text-success font-medium' : 'text-surface-600'}`}>
                     {importedStr}
                   </td>
                   {/* Phase 4: Per-field radio controls */}
@@ -329,7 +329,7 @@ export function ExtractionItemCard({
                             onChange={() => onFieldOverrideChange(field, 'existing')}
                             className="text-amber-600 focus:ring-amber-500"
                           />
-                          <span className="text-xs text-gray-600">Existing</span>
+                          <span className="text-xs text-surface-600">Existing</span>
                         </label>
                         <label className="flex items-center gap-1 cursor-pointer">
                           <input
@@ -337,15 +337,15 @@ export function ExtractionItemCard({
                             name={`field-${item.id}-${field}`}
                             checked={currentOverride !== 'existing'}
                             onChange={() => onFieldOverrideChange(field, 'imported')}
-                            className="text-green-600 focus:ring-green-500"
+                            className="text-success focus:ring-green-500"
                           />
-                          <span className="text-xs text-gray-600">Imported</span>
+                          <span className="text-xs text-surface-600">Imported</span>
                         </label>
                       </div>
                     </td>
                   )}
                   {onFieldOverrideChange && mergeAction === 'smart_merge' && !hasChange && (
-                    <td className="py-2 px-2 text-center text-xs text-gray-400">
+                    <td className="py-2 px-2 text-center text-xs text-surface-400">
                       Same
                     </td>
                   )}
@@ -373,7 +373,7 @@ export function ExtractionItemCard({
               checked={isSelected}
               onClick={(e) => e.stopPropagation()}
               onChange={() => onToggleSelect()}
-              className="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+              className="h-4 w-4 text-info rounded border-surface-300 focus:ring-blue-500"
             />
           )}
           {/* Duplicate badge indicator */}
@@ -387,15 +387,15 @@ export function ExtractionItemCard({
           <span className="text-xl">{config.icon}</span>
           <div>
             <div className="flex items-center gap-2">
-              <span className="text-xs font-medium text-gray-500 uppercase">{config.label}</span>
+              <span className="text-xs font-medium text-surface-500 uppercase">{config.label}</span>
               {isDuplicate && !isDisabled && (
                 <span className="text-xs bg-amber-100 text-amber-800 px-2 py-0.5 rounded font-medium">Duplicate</span>
               )}
               {statusBadge()}
               {mergeAction && !isDisabled && (
                 <span className={`text-xs px-2 py-0.5 rounded font-medium ${
-                  mergeAction === 'smart_merge' ? 'bg-blue-100 text-blue-800' :
-                  mergeAction === 'skip' ? 'bg-gray-100 text-gray-700' :
+                  mergeAction === 'smart_merge' ? 'bg-info-light text-info' :
+                  mergeAction === 'skip' ? 'bg-surface-100 text-surface-700' :
                   'bg-purple-100 text-purple-800'
                 }`}>
                   {mergeAction === 'smart_merge' ? 'Merge' :
@@ -403,13 +403,13 @@ export function ExtractionItemCard({
                 </span>
               )}
             </div>
-            <p className="font-medium text-gray-900">{getMainValue()}</p>
+            <p className="font-medium text-navy">{getMainValue()}</p>
           </div>
         </div>
         <div className="flex items-center gap-3">
           <ConfidenceBadge score={item.confidence_score} />
           <svg
-            className={`h-5 w-5 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            className={`h-5 w-5 text-surface-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -460,8 +460,8 @@ export function ExtractionItemCard({
             onClick={(e) => { e.stopPropagation(); onMergeActionChange('smart_merge'); }}
             className={`flex-1 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
               mergeAction === 'smart_merge'
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-blue-50 hover:text-blue-700'
+                ? 'bg-info text-white'
+                : 'bg-surface-100 text-surface-700 hover:bg-info-light hover:text-info'
             }`}
           >
             Approve (Smart Merge)
@@ -470,8 +470,8 @@ export function ExtractionItemCard({
             onClick={(e) => { e.stopPropagation(); onMergeActionChange('skip'); }}
             className={`flex-1 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
               mergeAction === 'skip'
-                ? 'bg-gray-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                ? 'bg-surface-600 text-white'
+                : 'bg-surface-100 text-surface-700 hover:bg-surface-200'
             }`}
           >
             Skip / Keep Existing
@@ -481,7 +481,7 @@ export function ExtractionItemCard({
             className={`flex-1 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
               mergeAction === 'create_new'
                 ? 'bg-purple-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-purple-50 hover:text-purple-700'
+                : 'bg-surface-100 text-surface-700 hover:bg-purple-50 hover:text-purple-700'
             }`}
           >
             Create New

--- a/frontend/src/components/pdf-import/ExtractionReview.tsx
+++ b/frontend/src/components/pdf-import/ExtractionReview.tsx
@@ -151,7 +151,7 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <svg className="animate-spin h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin h-8 w-8 text-info" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
         </svg>
@@ -161,9 +161,9 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
 
   if (error && !extraction) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-        <p className="text-red-600">{error}</p>
-        <button onClick={onBack} className="mt-2 text-sm text-red-600 hover:text-red-700 underline">
+      <div className="bg-danger-light border border-danger-light rounded-lg p-4">
+        <p className="text-danger">{error}</p>
+        <button onClick={onBack} className="mt-2 text-sm text-danger hover:text-danger underline">
           Go back
         </button>
       </div>
@@ -173,8 +173,8 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
   if (!extraction || extraction.items.length === 0) {
     return (
       <div className="text-center py-8">
-        <p className="text-gray-500">No data was extracted from this document.</p>
-        <button onClick={onBack} className="mt-4 text-blue-600 hover:text-blue-700">
+        <p className="text-surface-500">No data was extracted from this document.</p>
+        <button onClick={onBack} className="mt-4 text-info hover:text-info">
           Go back
         </button>
       </div>
@@ -195,42 +195,42 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
         <div>
           <button
             onClick={onBack}
-            className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+            className="text-sm text-surface-500 hover:text-surface-700 flex items-center gap-1"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             Back to uploads
           </button>
-          <h3 className="mt-2 text-lg font-medium text-gray-900">
+          <h3 className="mt-2 text-lg font-medium text-navy">
             Review Extracted Data
           </h3>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-surface-500">
             From: {upload.original_filename}
           </p>
         </div>
       </div>
 
       {/* Confidence legend */}
-      <div className="bg-gray-50 rounded-lg p-3 flex items-center gap-4 text-xs">
-        <span className="text-gray-500">Confidence:</span>
+      <div className="bg-surface rounded-lg p-3 flex items-center gap-4 text-xs">
+        <span className="text-surface-500">Confidence:</span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-green-500"></span>
+          <span className="w-3 h-3 rounded bg-success"></span>
           High (80%+)
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-yellow-500"></span>
+          <span className="w-3 h-3 rounded bg-warning"></span>
           Medium (50-80%)
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-red-500"></span>
+          <span className="w-3 h-3 rounded bg-danger"></span>
           Low (&lt;50%)
         </span>
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-lg p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
 
@@ -238,15 +238,15 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
       {pendingItems.length > 0 && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h4 className="font-medium text-gray-900">
+            <h4 className="font-medium text-navy">
               Items to Review ({pendingItems.length})
             </h4>
             <div className="flex items-center gap-2 text-sm">
-              <button onClick={selectAll} className="text-blue-600 hover:text-blue-700">
+              <button onClick={selectAll} className="text-info hover:text-info">
                 Select all
               </button>
-              <span className="text-gray-300">|</span>
-              <button onClick={selectNone} className="text-blue-600 hover:text-blue-700">
+              <span className="text-surface-300">|</span>
+              <button onClick={selectNone} className="text-info hover:text-info">
                 Select none
               </button>
             </div>
@@ -269,7 +269,7 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
             <button
               onClick={handleApprove}
               disabled={selectedIds.size === 0 || isApproving}
-              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 bg-success text-white rounded-md hover:bg-success disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isApproving ? (
                 <>
@@ -292,7 +292,7 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
             <button
               onClick={handleReject}
               disabled={selectedIds.size === 0 || isRejecting}
-              className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 bg-danger text-white rounded-md hover:bg-danger disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isRejecting ? 'Rejecting...' : `Reject Selected (${selectedIds.size})`}
             </button>
@@ -303,7 +303,7 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
       {/* Processed items */}
       {processedItems.length > 0 && (
         <div className="mt-8">
-          <h4 className="font-medium text-gray-900 mb-3">
+          <h4 className="font-medium text-navy mb-3">
             Already Processed ({processedItems.length})
           </h4>
           <div className="space-y-3 opacity-75">
@@ -322,17 +322,17 @@ export function ExtractionReview({ petId, upload, onBack, onApprovalComplete }: 
 
       {/* All done */}
       {pendingItems.length === 0 && processedItems.length > 0 && (
-        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
-          <svg className="mx-auto h-12 w-12 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <div className="bg-success-light border border-success-light rounded-lg p-4 text-center">
+          <svg className="mx-auto h-12 w-12 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
-          <h3 className="mt-2 text-lg font-medium text-green-900">All items processed!</h3>
-          <p className="text-sm text-green-600 mt-1">
+          <h3 className="mt-2 text-lg font-medium text-success">All items processed!</h3>
+          <p className="text-sm text-success mt-1">
             The extracted data has been reviewed and added to your pet's records.
           </p>
           <button
             onClick={onBack}
-            className="mt-4 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+            className="mt-4 px-4 py-2 bg-success text-white rounded-md hover:bg-success"
           >
             Back to uploads
           </button>

--- a/frontend/src/components/pdf-import/FieldEditor.tsx
+++ b/frontend/src/components/pdf-import/FieldEditor.tsx
@@ -59,13 +59,13 @@ export function FieldEditor({
   };
 
   return (
-    <div className="flex items-center gap-3 py-2 border-b border-gray-100 last:border-0">
+    <div className="flex items-center gap-3 py-2 border-b border-surface-100 last:border-0">
       <div className="flex items-center gap-1.5 w-36 flex-shrink-0">
-        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <span className="text-xs font-medium text-surface-500 uppercase tracking-wider">
           {label}
         </span>
         {isModified && (
-          <span className="text-[10px] text-blue-600 font-medium uppercase">Modified</span>
+          <span className="text-[10px] text-info font-medium uppercase">Modified</span>
         )}
       </div>
       <div className="flex-1">
@@ -73,7 +73,7 @@ export function FieldEditor({
           <select
             value={localValue}
             onChange={handleSelectChange}
-            className="block w-full px-2 py-1 text-sm border border-gray-200 rounded bg-white focus:ring-blue-500 focus:border-blue-500"
+            className="block w-full px-2 py-1 text-sm border border-surface-200 rounded bg-white focus:ring-blue-500 focus:border-blue-500"
           >
             <option value="true">Yes</option>
             <option value="false">No</option>
@@ -82,7 +82,7 @@ export function FieldEditor({
           <select
             value={localValue}
             onChange={handleSelectChange}
-            className="block w-full px-2 py-1 text-sm border border-gray-200 rounded bg-white focus:ring-blue-500 focus:border-blue-500"
+            className="block w-full px-2 py-1 text-sm border border-surface-200 rounded bg-white focus:ring-blue-500 focus:border-blue-500"
           >
             <option value="">-</option>
             {options.map((opt) => (
@@ -98,7 +98,7 @@ export function FieldEditor({
             onChange={(e) => setLocalValue(e.target.value)}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
-            className="block w-full px-2 py-1 text-sm border border-gray-200 rounded bg-white focus:ring-blue-500 focus:border-blue-500"
+            className="block w-full px-2 py-1 text-sm border border-surface-200 rounded bg-white focus:ring-blue-500 focus:border-blue-500"
           />
         )}
       </div>

--- a/frontend/src/components/pdf-import/PdfUploadList.tsx
+++ b/frontend/src/components/pdf-import/PdfUploadList.tsx
@@ -84,7 +84,7 @@ export function PdfUploadList({
 
   if (uploads.length === 0) {
     return (
-      <div className="text-center py-8 text-gray-500">
+      <div className="text-center py-8 text-surface-500">
         <p>No PDF uploads yet</p>
         <p className="text-sm mt-1">Upload a veterinary document to get started</p>
       </div>
@@ -92,19 +92,19 @@ export function PdfUploadList({
   }
 
   return (
-    <div className="divide-y divide-gray-200">
+    <div className="divide-y divide-surface-200">
       {uploads.map((upload) => (
         <div key={upload.id} className="py-4 flex items-center justify-between">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-3">
-              <svg className="h-8 w-8 text-red-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="h-8 w-8 text-danger flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clipRule="evenodd" />
               </svg>
               <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">
+                <p className="text-sm font-medium text-navy truncate">
                   {upload.original_filename}
                 </p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-surface-500">
                   {formatFileSize(upload.file_size)} • {formatDocType(upload.document_type)} • {formatDate(upload.created_at)}
                 </p>
               </div>
@@ -119,7 +119,7 @@ export function PdfUploadList({
                 <button
                   onClick={() => handleProcess(upload)}
                   disabled={processingIds.has(upload.id)}
-                  className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                  className="px-3 py-1 text-sm bg-info text-white rounded hover:bg-info disabled:opacity-50"
                 >
                   {processingIds.has(upload.id) ? 'Processing...' : 'Process'}
                 </button>
@@ -128,7 +128,7 @@ export function PdfUploadList({
               {upload.status === 'completed' && (
                 <button
                   onClick={() => onUploadSelect(upload)}
-                  className="px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700"
+                  className="px-3 py-1 text-sm bg-success text-white rounded hover:bg-success"
                 >
                   Review
                 </button>
@@ -147,7 +147,7 @@ export function PdfUploadList({
               <button
                 onClick={() => handleDelete(upload.id)}
                 disabled={deletingIds.has(upload.id)}
-                className="p-1 text-gray-400 hover:text-red-500 disabled:opacity-50"
+                className="p-1 text-surface-400 hover:text-danger disabled:opacity-50"
                 title="Delete"
               >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/pdf-import/PdfUploadZone.tsx
+++ b/frontend/src/components/pdf-import/PdfUploadZone.tsx
@@ -72,13 +72,13 @@ export function PdfUploadZone({ petId, onUploadComplete }: PdfUploadZoneProps) {
     <div className="space-y-4">
       {/* Document type selector */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-surface-700 mb-1">
           Document Type
         </label>
         <select
           value={documentType}
           onChange={(e) => setDocumentType(e.target.value as DocumentType)}
-          className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+          className="block w-full px-3 py-2 border border-surface-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
         >
           <option value="vaccination_record">Vaccination Record</option>
           <option value="visit_summary">Visit Summary</option>
@@ -96,21 +96,21 @@ export function PdfUploadZone({ petId, onUploadComplete }: PdfUploadZoneProps) {
         className={`
           border-2 border-dashed rounded-lg p-8 text-center cursor-pointer
           transition-colors duration-200
-          ${isDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-gray-400'}
+          ${isDragOver ? 'border-info bg-info-light' : 'border-surface-300 hover:border-surface-400'}
           ${isUploading ? 'opacity-50 cursor-not-allowed' : ''}
         `}
       >
         {isUploading ? (
           <div className="flex flex-col items-center">
-            <svg className="animate-spin h-10 w-10 text-blue-500 mb-3" fill="none" viewBox="0 0 24 24">
+            <svg className="animate-spin h-10 w-10 text-info mb-3" fill="none" viewBox="0 0 24 24">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
-            <p className="text-gray-600">Uploading...</p>
+            <p className="text-surface-600">Uploading...</p>
           </div>
         ) : (
           <>
-            <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+            <svg className="mx-auto h-12 w-12 text-surface-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
               <path
                 d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
                 strokeWidth="2"
@@ -118,8 +118,8 @@ export function PdfUploadZone({ petId, onUploadComplete }: PdfUploadZoneProps) {
                 strokeLinejoin="round"
               />
             </svg>
-            <p className="mt-2 text-sm text-gray-600">
-              <label className="text-blue-600 hover:text-blue-500 cursor-pointer">
+            <p className="mt-2 text-sm text-surface-600">
+              <label className="text-info hover:text-info cursor-pointer">
                 <span>Upload a PDF</span>
                 <input
                   type="file"
@@ -131,14 +131,14 @@ export function PdfUploadZone({ petId, onUploadComplete }: PdfUploadZoneProps) {
               </label>
               {' '}or drag and drop
             </p>
-            <p className="mt-1 text-xs text-gray-500">PDF files up to 20MB</p>
+            <p className="mt-1 text-xs text-surface-500">PDF files up to 20MB</p>
           </>
         )}
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-md p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-md p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
     </div>

--- a/frontend/src/components/pdf-import/ProcessingStatus.tsx
+++ b/frontend/src/components/pdf-import/ProcessingStatus.tsx
@@ -8,7 +8,7 @@ interface ProcessingStatusProps {
 export function ProcessingStatus({ status, errorMessage }: ProcessingStatusProps) {
   const statusConfig = {
     pending: {
-      color: 'bg-yellow-100 text-yellow-800',
+      color: 'bg-warning-light text-warning-dark',
       icon: (
         <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
           <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
@@ -17,7 +17,7 @@ export function ProcessingStatus({ status, errorMessage }: ProcessingStatusProps
       label: 'Pending',
     },
     processing: {
-      color: 'bg-blue-100 text-blue-800',
+      color: 'bg-info-light text-info',
       icon: (
         <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
@@ -27,7 +27,7 @@ export function ProcessingStatus({ status, errorMessage }: ProcessingStatusProps
       label: 'Processing',
     },
     completed: {
-      color: 'bg-green-100 text-green-800',
+      color: 'bg-success-light text-success',
       icon: (
         <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
           <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
@@ -36,7 +36,7 @@ export function ProcessingStatus({ status, errorMessage }: ProcessingStatusProps
       label: 'Completed',
     },
     failed: {
-      color: 'bg-red-100 text-red-800',
+      color: 'bg-danger-light text-danger',
       icon: (
         <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
           <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
@@ -55,7 +55,7 @@ export function ProcessingStatus({ status, errorMessage }: ProcessingStatusProps
         {config.label}
       </span>
       {status === 'failed' && errorMessage && (
-        <p className="text-xs text-red-600 mt-1">{errorMessage}</p>
+        <p className="text-xs text-danger mt-1">{errorMessage}</p>
       )}
     </div>
   );

--- a/frontend/src/components/photo-import/ImageExtractionReview.tsx
+++ b/frontend/src/components/photo-import/ImageExtractionReview.tsx
@@ -151,7 +151,7 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <svg className="animate-spin h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin h-8 w-8 text-info" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
         </svg>
@@ -161,9 +161,9 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
 
   if (error && !extraction) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-        <p className="text-red-600">{error}</p>
-        <button onClick={onBack} className="mt-2 text-sm text-red-600 hover:text-red-700 underline">
+      <div className="bg-danger-light border border-danger-light rounded-lg p-4">
+        <p className="text-danger">{error}</p>
+        <button onClick={onBack} className="mt-2 text-sm text-danger hover:text-danger underline">
           Go back
         </button>
       </div>
@@ -173,11 +173,11 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
   if (!extraction || extraction.items.length === 0) {
     return (
       <div className="text-center py-8">
-        <p className="text-gray-500">No data was extracted from this image.</p>
-        <p className="text-sm text-gray-400 mt-1">
+        <p className="text-surface-500">No data was extracted from this image.</p>
+        <p className="text-sm text-surface-400 mt-1">
           Try uploading a clearer photo of the document or label.
         </p>
-        <button onClick={onBack} className="mt-4 text-blue-600 hover:text-blue-700">
+        <button onClick={onBack} className="mt-4 text-info hover:text-info">
           Go back
         </button>
       </div>
@@ -198,42 +198,42 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
         <div>
           <button
             onClick={onBack}
-            className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+            className="text-sm text-surface-500 hover:text-surface-700 flex items-center gap-1"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             Back to uploads
           </button>
-          <h3 className="mt-2 text-lg font-medium text-gray-900">
+          <h3 className="mt-2 text-lg font-medium text-navy">
             Review Extracted Data
           </h3>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-surface-500">
             From: {upload.original_filename}
           </p>
         </div>
       </div>
 
       {/* Confidence legend */}
-      <div className="bg-gray-50 rounded-lg p-3 flex items-center gap-4 text-xs">
-        <span className="text-gray-500">Confidence:</span>
+      <div className="bg-surface rounded-lg p-3 flex items-center gap-4 text-xs">
+        <span className="text-surface-500">Confidence:</span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-green-500"></span>
+          <span className="w-3 h-3 rounded bg-success"></span>
           High (80%+)
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-yellow-500"></span>
+          <span className="w-3 h-3 rounded bg-warning"></span>
           Medium (50-80%)
         </span>
         <span className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded bg-red-500"></span>
+          <span className="w-3 h-3 rounded bg-danger"></span>
           Low (&lt;50%)
         </span>
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-lg p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
 
@@ -241,15 +241,15 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
       {pendingItems.length > 0 && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h4 className="font-medium text-gray-900">
+            <h4 className="font-medium text-navy">
               Items to Review ({pendingItems.length})
             </h4>
             <div className="flex items-center gap-2 text-sm">
-              <button onClick={selectAll} className="text-blue-600 hover:text-blue-700">
+              <button onClick={selectAll} className="text-info hover:text-info">
                 Select all
               </button>
-              <span className="text-gray-300">|</span>
-              <button onClick={selectNone} className="text-blue-600 hover:text-blue-700">
+              <span className="text-surface-300">|</span>
+              <button onClick={selectNone} className="text-info hover:text-info">
                 Select none
               </button>
             </div>
@@ -272,7 +272,7 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
             <button
               onClick={handleApprove}
               disabled={selectedIds.size === 0 || isApproving}
-              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 bg-success text-white rounded-md hover:bg-success disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isApproving ? (
                 <>
@@ -295,7 +295,7 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
             <button
               onClick={handleReject}
               disabled={selectedIds.size === 0 || isRejecting}
-              className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              className="px-4 py-2 bg-danger text-white rounded-md hover:bg-danger disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             >
               {isRejecting ? 'Rejecting...' : `Reject Selected (${selectedIds.size})`}
             </button>
@@ -306,7 +306,7 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
       {/* Processed items */}
       {processedItems.length > 0 && (
         <div className="mt-8">
-          <h4 className="font-medium text-gray-900 mb-3">
+          <h4 className="font-medium text-navy mb-3">
             Already Processed ({processedItems.length})
           </h4>
           <div className="space-y-3 opacity-75">
@@ -325,17 +325,17 @@ export function ImageExtractionReview({ petId, upload, onBack, onApprovalComplet
 
       {/* All done */}
       {pendingItems.length === 0 && processedItems.length > 0 && (
-        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
-          <svg className="mx-auto h-12 w-12 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <div className="bg-success-light border border-success-light rounded-lg p-4 text-center">
+          <svg className="mx-auto h-12 w-12 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
-          <h3 className="mt-2 text-lg font-medium text-green-900">All items processed!</h3>
-          <p className="text-sm text-green-600 mt-1">
+          <h3 className="mt-2 text-lg font-medium text-success">All items processed!</h3>
+          <p className="text-sm text-success mt-1">
             The extracted data has been reviewed and added to your pet's records.
           </p>
           <button
             onClick={onBack}
-            className="mt-4 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+            className="mt-4 px-4 py-2 bg-success text-white rounded-md hover:bg-success"
           >
             Back to uploads
           </button>

--- a/frontend/src/components/photo-import/ImageUploadList.tsx
+++ b/frontend/src/components/photo-import/ImageUploadList.tsx
@@ -91,7 +91,7 @@ export function ImageUploadList({
 
   if (uploads.length === 0) {
     return (
-      <div className="text-center py-8 text-gray-500">
+      <div className="text-center py-8 text-surface-500">
         <p>No photo uploads yet</p>
         <p className="text-sm mt-1">Take a photo of a pet document or label to get started</p>
       </div>
@@ -99,7 +99,7 @@ export function ImageUploadList({
   }
 
   return (
-    <div className="divide-y divide-gray-200">
+    <div className="divide-y divide-surface-200">
       {uploads.map((upload) => (
         <div key={upload.id} className="py-4 flex items-center justify-between">
           <div className="flex-1 min-w-0">
@@ -114,10 +114,10 @@ export function ImageUploadList({
                 }}
               />
               <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">
+                <p className="text-sm font-medium text-navy truncate">
                   {upload.original_filename}
                 </p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-surface-500">
                   {formatFileSize(upload.file_size)} • {formatDocType(upload.document_type)} • {formatDate(upload.created_at)}
                 </p>
               </div>
@@ -132,7 +132,7 @@ export function ImageUploadList({
                 <button
                   onClick={() => handleProcess(upload)}
                   disabled={processingIds.has(upload.id)}
-                  className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                  className="px-3 py-1 text-sm bg-info text-white rounded hover:bg-info disabled:opacity-50"
                 >
                   {processingIds.has(upload.id) ? 'Processing...' : 'Extract Data'}
                 </button>
@@ -141,7 +141,7 @@ export function ImageUploadList({
               {upload.status === 'completed' && (
                 <button
                   onClick={() => onUploadSelect(upload)}
-                  className="px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700"
+                  className="px-3 py-1 text-sm bg-success text-white rounded hover:bg-success"
                 >
                   Review
                 </button>
@@ -160,7 +160,7 @@ export function ImageUploadList({
               <button
                 onClick={() => handleDelete(upload.id)}
                 disabled={deletingIds.has(upload.id)}
-                className="p-1 text-gray-400 hover:text-red-500 disabled:opacity-50"
+                className="p-1 text-surface-400 hover:text-danger disabled:opacity-50"
                 title="Delete"
               >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/photo-import/ImageUploadZone.tsx
+++ b/frontend/src/components/photo-import/ImageUploadZone.tsx
@@ -98,13 +98,13 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
     <div className="space-y-4">
       {/* Document type selector */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-surface-700 mb-1">
           What type of document is this?
         </label>
         <select
           value={documentType}
           onChange={(e) => setDocumentType(e.target.value as ImageDocumentType)}
-          className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+          className="block w-full px-3 py-2 border border-surface-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
         >
           <option value="vaccination_card">Vaccination Card</option>
           <option value="medication_label">Medication Label</option>
@@ -122,7 +122,7 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
         className={`
           border-2 border-dashed rounded-lg p-8 text-center cursor-pointer
           transition-colors duration-200
-          ${isDragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-gray-400'}
+          ${isDragOver ? 'border-info bg-info-light' : 'border-surface-300 hover:border-surface-400'}
           ${isUploading ? 'opacity-50 cursor-not-allowed' : ''}
         `}
       >
@@ -135,15 +135,15 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
                 className="h-24 w-24 object-cover rounded-lg mb-3 opacity-50"
               />
             )}
-            <svg className="animate-spin h-10 w-10 text-blue-500 mb-3" fill="none" viewBox="0 0 24 24">
+            <svg className="animate-spin h-10 w-10 text-info mb-3" fill="none" viewBox="0 0 24 24">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
-            <p className="text-gray-600">Uploading...</p>
+            <p className="text-surface-600">Uploading...</p>
           </div>
         ) : (
           <>
-            <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+            <svg className="mx-auto h-12 w-12 text-surface-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
               <path
                 d="M28 8H12a4 4 0 00-4 4v20m0 0v4a4 4 0 004 4h24a4 4 0 004-4V24M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4-4m4-12h8m-4-4v8"
                 strokeWidth="2"
@@ -151,8 +151,8 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
                 strokeLinejoin="round"
               />
             </svg>
-            <p className="mt-2 text-sm text-gray-600">
-              <label className="text-blue-600 hover:text-blue-500 cursor-pointer">
+            <p className="mt-2 text-sm text-surface-600">
+              <label className="text-info hover:text-info cursor-pointer">
                 <span>Take a photo or upload an image</span>
                 <input
                   type="file"
@@ -165,14 +165,14 @@ export function ImageUploadZone({ petId, onUploadComplete }: ImageUploadZoneProp
               </label>
               {' '}or drag and drop
             </p>
-            <p className="mt-1 text-xs text-gray-500">JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP up to 10MB</p>
+            <p className="mt-1 text-xs text-surface-500">JPEG, PNG, WebP, GIF, HEIC, TIFF, or BMP up to 10MB</p>
           </>
         )}
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-md p-3">
-          <p className="text-sm text-red-600">{error}</p>
+        <div className="bg-danger-light border border-danger-light rounded-md p-3">
+          <p className="text-sm text-danger">{error}</p>
         </div>
       )}
     </div>

--- a/frontend/src/components/photo-import/PhotoImportSection.tsx
+++ b/frontend/src/components/photo-import/PhotoImportSection.tsx
@@ -76,7 +76,7 @@ export function PhotoImportSection({ petId }: PhotoImportSectionProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <svg className="animate-spin h-8 w-8 text-blue-500" fill="none" viewBox="0 0 24 24">
+        <svg className="animate-spin h-8 w-8 text-info" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
         </svg>
@@ -86,9 +86,9 @@ export function PhotoImportSection({ petId }: PhotoImportSectionProps) {
 
   if (error) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-        <p className="text-red-600">{error}</p>
-        <button onClick={loadUploads} className="mt-2 text-sm text-red-600 hover:text-red-700 underline">
+      <div className="bg-danger-light border border-danger-light rounded-lg p-4">
+        <p className="text-danger">{error}</p>
+        <button onClick={loadUploads} className="mt-2 text-sm text-danger hover:text-danger underline">
           Try again
         </button>
       </div>
@@ -108,15 +108,15 @@ export function PhotoImportSection({ petId }: PhotoImportSectionProps) {
 
   return (
     <div className="space-y-6">
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <h3 className="text-sm font-medium text-blue-900 flex items-center gap-2">
+      <div className="bg-info-light border border-info-light rounded-lg p-4">
+        <h3 className="text-sm font-medium text-info flex items-center gap-2">
           <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
           Photo-to-Data Import
         </h3>
-        <p className="mt-1 text-sm text-blue-700">
+        <p className="mt-1 text-sm text-info">
           Take a photo of vaccination cards, medication labels, or pet ID tags.
           We'll use AI to extract the information and add it to your pet's health records.
         </p>
@@ -126,7 +126,7 @@ export function PhotoImportSection({ petId }: PhotoImportSectionProps) {
 
       {uploads.length > 0 && (
         <div>
-          <h4 className="text-sm font-medium text-gray-900 mb-3">Previous Uploads</h4>
+          <h4 className="text-sm font-medium text-navy mb-3">Previous Uploads</h4>
           <ImageUploadList
             petId={petId}
             uploads={uploads}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -511,12 +511,7 @@ h1, h2, h3, h4, h5, h6 {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 12px;
-}
-
-@media (min-width: 640px) {
-  .pet-profile-stats {
-    grid-template-columns: repeat(4, 1fr);
-  }
+  margin-bottom: 16px;
 }
 
 .pet-profile-stat {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,6 +19,7 @@
   --color-danger-dark: #922B21;
   --color-danger-light: #FDECEB;
   --color-warning: #E6A817;
+  --color-warning-dark: #8B6914;
   --color-warning-light: #FFF8E1;
   --color-success: #27AE60;
   --color-success-light: #EAFAF1;
@@ -66,6 +67,22 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ========== Component Classes ========== */
 @layer components {
+  .page-title {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-navy);
+    line-height: 1.2;
+  }
+
+  .section-title {
+    font-family: var(--font-heading);
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--color-navy);
+    line-height: 1.3;
+  }
+
   .btn {
     @apply inline-flex items-center justify-center gap-2 font-semibold transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
     font-family: var(--font-body);
@@ -139,7 +156,7 @@ h1, h2, h3, h4, h5, h6 {
   .input {
     @apply w-full border focus:outline-none focus:ring-2 focus:border-transparent;
     font-family: var(--font-body);
-    padding: 10px 14px;
+    padding: 12px 16px;
     border-color: var(--color-surface-200);
     border-radius: var(--radius-sm);
     font-size: 0.9375rem;
@@ -157,9 +174,17 @@ h1, h2, h3, h4, h5, h6 {
     border: 1px solid var(--color-surface-200);
     border-radius: var(--radius-lg);
     padding: 24px;
-    transition: box-shadow 0.15s ease;
   }
-  .card:hover {
+
+  .card-interactive {
+    background: var(--color-white);
+    border: 1px solid var(--color-surface-200);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    transition: box-shadow 0.15s ease;
+    cursor: pointer;
+  }
+  .card-interactive:hover {
     box-shadow: var(--shadow-md);
   }
 
@@ -171,7 +196,7 @@ h1, h2, h3, h4, h5, h6 {
   /* Badge system */
   .badge {
     @apply inline-flex items-center gap-1 whitespace-nowrap;
-    padding: 3px 10px;
+    padding: 4px 12px;
     border-radius: 100px;
     font-size: 0.75rem;
     font-weight: 600;
@@ -222,14 +247,14 @@ h1, h2, h3, h4, h5, h6 {
   }
   .data-table th {
     @apply text-left text-xs font-semibold uppercase tracking-wider;
-    padding: 10px 16px;
+    padding: 12px 16px;
     color: var(--color-surface-500);
     border-bottom: 2px solid var(--color-surface-200);
     background: var(--color-surface);
   }
   .data-table td {
     @apply text-sm;
-    padding: 14px 16px;
+    padding: 16px;
     border-bottom: 1px solid var(--color-surface-100);
   }
   .data-table tr:hover td {
@@ -289,8 +314,8 @@ h1, h2, h3, h4, h5, h6 {
 .pet-profile-nav-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
+  gap: 12px;
+  padding: 12px 16px;
   border-radius: var(--radius-sm);
   font-size: 0.875rem;
   font-weight: 500;
@@ -357,7 +382,7 @@ h1, h2, h3, h4, h5, h6 {
   text-align: left;
   background: none;
   border: none;
-  padding: 5px 10px;
+  padding: 4px 12px;
   border-radius: var(--radius-sm);
   font-size: 0.8125rem;
   font-weight: 400;
@@ -393,8 +418,8 @@ h1, h2, h3, h4, h5, h6 {
   position: absolute;
   top: 0;
   right: 0;
-  width: 72px;
-  height: 36px; /* match pill height */
+  width: 56px;
+  height: 100%; /* match container height */
   background: linear-gradient(to right, transparent 0%, var(--color-surface) 60%);
   pointer-events: none;
   z-index: 1;
@@ -412,7 +437,7 @@ h1, h2, h3, h4, h5, h6 {
   overflow-x: auto;
   padding-bottom: 16px;
   margin-bottom: 16px;
-  padding-right: 48px; /* space so last pill isn't under the fade */
+  padding-right: 64px; /* space so last pill isn't under the fade */
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
@@ -557,7 +582,7 @@ h1, h2, h3, h4, h5, h6 {
 .health-accordion-title {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   font-weight: 600;
   font-size: 0.9375rem;
   color: var(--color-navy);
@@ -589,7 +614,7 @@ h1, h2, h3, h4, h5, h6 {
 .emergency-card-preview-header {
   background: var(--color-danger);
   color: white;
-  padding: 10px 16px;
+  padding: 12px 16px;
   display: flex;
   align-items: center;
   gap: 8px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -535,7 +535,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .pet-profile-stat-value {
-  font-family: var(--font-heading);
+  font-family: var(--font-body);
   font-size: 1.75rem;
   font-weight: 700;
   line-height: 1;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,19 +28,20 @@
 
   /* Surfaces */
   --color-white: #FFFFFF;
-  --color-surface: #F8F9FA;
-  --color-surface-100: #F1F3F5;
-  --color-surface-200: #E2E5E9;
-  --color-surface-300: #CED4DA;
-  --color-surface-400: #ADB5BD;
-  --color-surface-500: #868E96;
-  --color-surface-600: #5A6270;
-  --color-surface-700: #3D4551;
+  --color-surface: #FAF9F7;
+  --color-surface-100: #F5F3F0;
+  --color-surface-200: #E8E5E0;
+  --color-surface-300: #D5D0CA;
+  --color-surface-400: #B5AFA6;
+  --color-surface-500: #8C857C;
+  --color-surface-600: #635C54;
+  --color-surface-700: #463F38;
+  --color-warm-bg: #FFF8F3;
 
   /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(27,42,74,0.05);
-  --shadow-md: 0 2px 8px rgba(27,42,74,0.08);
-  --shadow-lg: 0 4px 16px rgba(27,42,74,0.1);
+  --shadow-sm: 0 1px 2px rgba(70,63,56,0.06);
+  --shadow-md: 0 2px 8px rgba(70,63,56,0.08);
+  --shadow-lg: 0 4px 16px rgba(70,63,56,0.10);
 
   /* Radii */
   --radius-sm: 8px;
@@ -598,6 +599,10 @@ h1, h2, h3, h4, h5, h6 {
   transform: rotate(180deg);
 }
 
+.health-accordion[open] {
+  border-left: 3px solid var(--color-navy);
+}
+
 .health-accordion-content {
   padding: 0 20px 20px;
   border-top: 1px solid var(--color-surface-100);
@@ -606,13 +611,13 @@ h1, h2, h3, h4, h5, h6 {
 /* ========== Emergency Card Preview ========== */
 .emergency-card-preview {
   background: var(--color-white);
-  border: 2px solid var(--color-danger);
+  border: 1.5px solid var(--color-surface-300);
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
 .emergency-card-preview-header {
-  background: var(--color-danger);
+  background: var(--color-navy);
   color: white;
   padding: 12px 16px;
   display: flex;

--- a/frontend/src/pages/AcceptInvite.tsx
+++ b/frontend/src/pages/AcceptInvite.tsx
@@ -68,7 +68,7 @@ export default function AcceptInvite() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-surface flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
       </div>
     );
@@ -76,15 +76,15 @@ export default function AcceptInvite() {
 
   if (error && !invite) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-surface flex items-center justify-center p-4">
         <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8 text-center">
-          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg className="w-8 h-8 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <div className="w-16 h-16 bg-danger-light rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-danger" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </div>
-          <h1 className="text-xl font-bold text-gray-900 mb-2">Invalid Invitation</h1>
-          <p className="text-gray-600 mb-6">{error}</p>
+          <h1 className="text-xl font-bold text-navy mb-2">Invalid Invitation</h1>
+          <p className="text-surface-600 mb-6">{error}</p>
           <Link to="/dashboard" className="btn-primary inline-block">
             Go to Dashboard
           </Link>
@@ -94,23 +94,23 @@ export default function AcceptInvite() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-surface flex items-center justify-center p-4">
       <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8">
         <div className="text-center mb-6">
           <div className="w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
             <span className="text-3xl">🐾</span>
           </div>
-          <h1 className="text-2xl font-bold text-gray-900">You've been invited!</h1>
-          <p className="text-gray-600 mt-2">
+          <h1 className="text-2xl font-bold text-navy">You've been invited!</h1>
+          <p className="text-surface-600 mt-2">
             Someone wants to share access to their pet with you.
           </p>
         </div>
 
         {invite && (
-          <div className="bg-gray-50 rounded-lg p-4 mb-6">
+          <div className="bg-surface rounded-lg p-4 mb-6">
             <div className="text-center">
-              <p className="text-lg font-semibold text-gray-900">{invite.petName}</p>
-              <p className="text-sm text-gray-500 mt-1">
+              <p className="text-lg font-semibold text-navy">{invite.petName}</p>
+              <p className="text-sm text-surface-500 mt-1">
                 Role: <span className="font-medium capitalize">{invite.role}</span>
               </p>
             </div>
@@ -118,14 +118,14 @@ export default function AcceptInvite() {
         )}
 
         {error && (
-          <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+          <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
             {error}
           </div>
         )}
 
         {!user ? (
           <div className="space-y-3">
-            <p className="text-sm text-gray-600 text-center">
+            <p className="text-sm text-surface-600 text-center">
               Please sign in or create an account to accept this invitation.
             </p>
             <Link
@@ -143,7 +143,7 @@ export default function AcceptInvite() {
           </div>
         ) : (
           <div className="space-y-3">
-            <p className="text-sm text-gray-600 text-center">
+            <p className="text-sm text-surface-600 text-center">
               Signed in as <span className="font-medium">{user.email}</span>
             </p>
             <button

--- a/frontend/src/pages/AccountSettings.tsx
+++ b/frontend/src/pages/AccountSettings.tsx
@@ -97,7 +97,7 @@ export default function AccountSettings() {
 
       {/* Profile Section */}
       <div className="card mb-6">
-        <h2 className="text-lg font-semibold text-navy mb-4">Profile Information</h2>
+        <h2 className="section-title mb-4">Profile Information</h2>
 
         {profileError && (
           <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
@@ -166,7 +166,7 @@ export default function AccountSettings() {
 
       {/* Password Section */}
       <div className="card mb-6">
-        <h2 className="text-lg font-semibold text-navy mb-4">Change Password</h2>
+        <h2 className="section-title mb-4">Change Password</h2>
 
         {passwordError && (
           <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
@@ -237,16 +237,16 @@ export default function AccountSettings() {
 
       {/* Subscription Section */}
       <div className="card">
-        <h2 className="text-lg font-semibold text-navy mb-4">Subscription</h2>
+        <h2 className="section-title mb-4">Subscription</h2>
 
         <div className="space-y-3">
-          <div className="flex justify-between items-center py-2 border-b border-surface-200">
+          <div className="flex justify-between items-center py-3 border-b border-surface-200">
             <span className="text-surface-600">Current Plan</span>
             <span className="font-medium text-navy">{subscriptionInfo.tier}</span>
           </div>
 
           {subscriptionInfo.status && (
-            <div className="flex justify-between items-center py-2 border-b border-surface-200">
+            <div className="flex justify-between items-center py-3 border-b border-surface-200">
               <span className="text-surface-600">Status</span>
               <span>
                 {subscriptionInfo.status === 'active' && (
@@ -266,7 +266,7 @@ export default function AccountSettings() {
           )}
 
           {subscription?.currentPeriodEnd && (
-            <div className="flex justify-between items-center py-2 border-b border-surface-200">
+            <div className="flex justify-between items-center py-3 border-b border-surface-200">
               <span className="text-surface-600">
                 {subscription.status === 'canceled' ? 'Access Until' : 'Next Billing Date'}
               </span>

--- a/frontend/src/pages/AccountSettings.tsx
+++ b/frontend/src/pages/AccountSettings.tsx
@@ -86,27 +86,34 @@ export default function AccountSettings() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-8">Account Settings</h1>
+      <div className="breadcrumb">
+        <Link to="/dashboard">Dashboard</Link>
+        <span className="sep">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </span>
+        <span className="current">Account Settings</span>
+      </div>
+      <h1 className="page-title mb-8">Account Settings</h1>
 
       {/* Profile Section */}
       <div className="card mb-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Profile Information</h2>
+        <h2 className="text-lg font-semibold text-navy mb-4">Profile Information</h2>
 
         {profileError && (
-          <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+          <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
             {profileError}
           </div>
         )}
 
         {profileSuccess && (
-          <div className="mb-4 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-lg">
+          <div className="mb-4 bg-success-light border border-success-light text-success px-4 py-3 rounded-lg">
             {profileSuccess}
           </div>
         )}
 
         <form onSubmit={handleSaveProfile} className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-surface-700 mb-1">
               Email
             </label>
             <input
@@ -114,13 +121,13 @@ export default function AccountSettings() {
               id="email"
               value={user?.email || ''}
               disabled
-              className="input w-full bg-gray-100 cursor-not-allowed"
+              className="input w-full bg-surface-100 cursor-not-allowed"
             />
-            <p className="mt-1 text-sm text-gray-500">Email cannot be changed</p>
+            <p className="mt-1 text-sm text-surface-500">Email cannot be changed</p>
           </div>
 
           <div>
-            <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="name" className="block text-sm font-medium text-surface-700 mb-1">
               Name
             </label>
             <input
@@ -134,7 +141,7 @@ export default function AccountSettings() {
           </div>
 
           <div>
-            <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="phone" className="block text-sm font-medium text-surface-700 mb-1">
               Phone (optional)
             </label>
             <input
@@ -159,23 +166,23 @@ export default function AccountSettings() {
 
       {/* Password Section */}
       <div className="card mb-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Change Password</h2>
+        <h2 className="text-lg font-semibold text-navy mb-4">Change Password</h2>
 
         {passwordError && (
-          <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+          <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
             {passwordError}
           </div>
         )}
 
         {passwordSuccess && (
-          <div className="mb-4 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-lg">
+          <div className="mb-4 bg-success-light border border-success-light text-success px-4 py-3 rounded-lg">
             {passwordSuccess}
           </div>
         )}
 
         <form onSubmit={handleChangePassword} className="space-y-4">
           <div>
-            <label htmlFor="currentPassword" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="currentPassword" className="block text-sm font-medium text-surface-700 mb-1">
               Current Password
             </label>
             <input
@@ -189,7 +196,7 @@ export default function AccountSettings() {
           </div>
 
           <div>
-            <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="newPassword" className="block text-sm font-medium text-surface-700 mb-1">
               New Password
             </label>
             <input
@@ -204,7 +211,7 @@ export default function AccountSettings() {
           </div>
 
           <div>
-            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-surface-700 mb-1">
               Confirm New Password
             </label>
             <input
@@ -230,40 +237,40 @@ export default function AccountSettings() {
 
       {/* Subscription Section */}
       <div className="card">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Subscription</h2>
+        <h2 className="text-lg font-semibold text-navy mb-4">Subscription</h2>
 
         <div className="space-y-3">
-          <div className="flex justify-between items-center py-2 border-b border-gray-200">
-            <span className="text-gray-600">Current Plan</span>
-            <span className="font-medium text-gray-900">{subscriptionInfo.tier}</span>
+          <div className="flex justify-between items-center py-2 border-b border-surface-200">
+            <span className="text-surface-600">Current Plan</span>
+            <span className="font-medium text-navy">{subscriptionInfo.tier}</span>
           </div>
 
           {subscriptionInfo.status && (
-            <div className="flex justify-between items-center py-2 border-b border-gray-200">
-              <span className="text-gray-600">Status</span>
+            <div className="flex justify-between items-center py-2 border-b border-surface-200">
+              <span className="text-surface-600">Status</span>
               <span>
                 {subscriptionInfo.status === 'active' && (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-success-light text-success">Active</span>
                 )}
                 {subscriptionInfo.status === 'trialing' && (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-info-light text-info">Trial</span>
                 )}
                 {subscriptionInfo.status === 'past_due' && (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">Past Due</span>
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-warning-light text-warning-dark">Past Due</span>
                 )}
                 {subscriptionInfo.status === 'canceled' && (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Canceled</span>
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-danger-light text-danger">Canceled</span>
                 )}
               </span>
             </div>
           )}
 
           {subscription?.currentPeriodEnd && (
-            <div className="flex justify-between items-center py-2 border-b border-gray-200">
-              <span className="text-gray-600">
+            <div className="flex justify-between items-center py-2 border-b border-surface-200">
+              <span className="text-surface-600">
                 {subscription.status === 'canceled' ? 'Access Until' : 'Next Billing Date'}
               </span>
-              <span className="font-medium text-gray-900">
+              <span className="font-medium text-navy">
                 {subscription.currentPeriodEnd.toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'long',
@@ -275,7 +282,7 @@ export default function AccountSettings() {
         </div>
 
         <div className="mt-4">
-          <Link to="/billing" className="btn-outline inline-block">
+          <Link to="/billing" className="btn btn-secondary inline-flex">
             Manage Subscription
           </Link>
         </div>

--- a/frontend/src/pages/BillingSettings.tsx
+++ b/frontend/src/pages/BillingSettings.tsx
@@ -1,11 +1,49 @@
-import { useState } from 'react';
+import { useState, Component, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { billingApi } from '../api/billing';
 import PaymentMethodList from '../components/PaymentMethodList';
 import AddPaymentMethodModal from '../components/AddPaymentMethodModal';
 
-export default function BillingSettings() {
+// Simple error boundary to prevent a render crash from blanking the entire page
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+interface ErrorBoundaryState {
+  hasError: boolean;
+  message: string;
+}
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, message: error.message };
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold text-navy mb-4">Billing Settings</h1>
+          <div className="card">
+            <p className="text-danger font-medium mb-2">Something went wrong loading this page.</p>
+            <p className="text-surface-600 text-sm">{this.state.message}</p>
+            <button
+              className="btn btn-secondary mt-4"
+              onClick={() => window.location.reload()}
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function BillingSettingsContent() {
   const { token, subscription, refreshSubscription } = useAuth();
   const [isLoadingCancel, setIsLoadingCancel] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
@@ -35,19 +73,19 @@ export default function BillingSettings() {
 
   const getStatusBadge = () => {
     if (!subscription) {
-      return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">Free</span>;
+      return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-surface-100 text-navy">Free</span>;
     }
     switch (subscription.status) {
       case 'active':
-        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>;
+        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-success-light text-success">Active</span>;
       case 'trialing':
-        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Trial</span>;
+        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-info-light text-info">Trial</span>;
       case 'past_due':
-        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">Past Due</span>;
+        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-warning-light text-warning-dark">Past Due</span>;
       case 'canceled':
-        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Canceled</span>;
+        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-danger-light text-danger">Canceled</span>;
       default:
-        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">Free</span>;
+        return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-surface-100 text-navy">Free</span>;
     }
   };
 
@@ -60,40 +98,47 @@ export default function BillingSettings() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold text-gray-900 mb-8">Billing Settings</h1>
+      <div className="breadcrumb">
+        <Link to="/dashboard">Dashboard</Link>
+        <span className="sep">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </span>
+        <span className="current">Billing</span>
+      </div>
+      <h1 className="page-title mb-8">Billing Settings</h1>
 
       {error && (
-        <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+        <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
           {error}
         </div>
       )}
 
       {successMessage && (
-        <div className="mb-6 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-lg">
+        <div className="mb-6 bg-success-light border border-success-light text-success px-4 py-3 rounded-lg">
           {successMessage}
         </div>
       )}
 
       <div className="card">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Current Subscription</h2>
+        <h2 className="text-lg font-semibold text-navy mb-4">Current Subscription</h2>
 
         <div className="space-y-4">
-          <div className="flex justify-between items-center py-3 border-b border-gray-200">
-            <span className="text-gray-600">Plan</span>
-            <span className="font-medium text-gray-900">{getTierDisplay()}</span>
+          <div className="flex justify-between items-center py-3 border-b border-surface-200">
+            <span className="text-surface-600">Plan</span>
+            <span className="font-medium text-navy">{getTierDisplay()}</span>
           </div>
 
-          <div className="flex justify-between items-center py-3 border-b border-gray-200">
-            <span className="text-gray-600">Status</span>
+          <div className="flex justify-between items-center py-3 border-b border-surface-200">
+            <span className="text-surface-600">Status</span>
             {getStatusBadge()}
           </div>
 
           {isPremium && subscription?.currentPeriodEnd && (
-            <div className="flex justify-between items-center py-3 border-b border-gray-200">
-              <span className="text-gray-600">
+            <div className="flex justify-between items-center py-3 border-b border-surface-200">
+              <span className="text-surface-600">
                 {subscription.status === 'canceled' ? 'Access Until' : 'Next Billing Date'}
               </span>
-              <span className="font-medium text-gray-900">
+              <span className="font-medium text-navy">
                 {subscription.currentPeriodEnd.toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'long',
@@ -121,15 +166,15 @@ export default function BillingSettings() {
               {isActive && subscription?.status !== 'canceled' && (
                 <button
                   onClick={() => setShowCancelConfirm(true)}
-                  className="w-full btn-outline text-red-600 border-red-300 hover:bg-red-50"
+                  className="w-full btn btn-ghost border border-danger text-danger hover:bg-danger-light"
                 >
                   Cancel Subscription
                 </button>
               )}
 
               {subscription?.status === 'canceled' && (
-                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                  <p className="text-sm text-yellow-800">
+                <div className="bg-warning-light border border-warning-light rounded-lg p-4">
+                  <p className="text-sm text-warning-dark">
                     Your subscription is canceled but you still have access until{' '}
                     {subscription.currentPeriodEnd?.toLocaleDateString('en-US', {
                       year: 'numeric',
@@ -145,8 +190,8 @@ export default function BillingSettings() {
               )}
 
               {subscription?.status === 'past_due' && (
-                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                  <p className="text-sm text-yellow-800 mb-2">
+                <div className="bg-warning-light border border-warning-light rounded-lg p-4">
+                  <p className="text-sm text-warning-dark mb-2">
                     Your payment is past due. Please update your payment method to continue your subscription.
                   </p>
                   <button
@@ -184,22 +229,22 @@ export default function BillingSettings() {
       {showCancelConfirm && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">Cancel Subscription?</h3>
-            <p className="text-gray-600 mb-6">
+            <h3 className="text-lg font-semibold text-navy mb-2">Cancel Subscription?</h3>
+            <p className="text-surface-600 mb-6">
               Are you sure you want to cancel your Premium subscription? You will retain access to
               premium features until the end of your current billing period.
             </p>
             <div className="flex space-x-3">
               <button
                 onClick={() => setShowCancelConfirm(false)}
-                className="flex-1 btn-outline"
+                className="flex-1 btn btn-secondary"
               >
                 Keep Subscription
               </button>
               <button
                 onClick={handleCancelSubscription}
                 disabled={isLoadingCancel}
-                className="flex-1 bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50"
+                className="flex-1 btn btn-danger disabled:opacity-50"
               >
                 {isLoadingCancel ? 'Canceling...' : 'Yes, Cancel'}
               </button>
@@ -208,5 +253,13 @@ export default function BillingSettings() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function BillingSettings() {
+  return (
+    <ErrorBoundary>
+      <BillingSettingsContent />
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/pages/BillingSettings.tsx
+++ b/frontend/src/pages/BillingSettings.tsx
@@ -120,7 +120,7 @@ function BillingSettingsContent() {
       )}
 
       <div className="card">
-        <h2 className="text-lg font-semibold text-navy mb-4">Current Subscription</h2>
+        <h2 className="section-title mb-4">Current Subscription</h2>
 
         <div className="space-y-4">
           <div className="flex justify-between items-center py-3 border-b border-surface-200">
@@ -152,9 +152,9 @@ function BillingSettingsContent() {
         {/* Actions */}
         <div className="mt-6 space-y-3">
           {isFreeTier ? (
-            <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
-              <h3 className="font-medium text-primary-900 mb-2">Upgrade to Premium</h3>
-              <p className="text-sm text-primary-700 mb-4">
+            <div className="bg-warm border border-surface-200 rounded-lg p-4">
+              <h3 className="font-medium text-navy mb-2">Upgrade to Premium</h3>
+              <p className="text-sm text-surface-600 mb-4">
                 Unlock unlimited pets, advanced health tracking, and priority support.
               </p>
               <Link to="/pricing" className="btn-primary inline-block">
@@ -183,7 +183,7 @@ function BillingSettingsContent() {
                     })}
                     .
                   </p>
-                  <Link to="/pricing" className="text-sm text-primary-600 hover:text-primary-500 font-medium mt-2 inline-block">
+                  <Link to="/pricing" className="text-sm text-steel hover:text-steel-dark font-medium mt-2 inline-block">
                     Resubscribe
                   </Link>
                 </div>
@@ -196,7 +196,7 @@ function BillingSettingsContent() {
                   </p>
                   <button
                     onClick={() => setShowUpdatePayment(true)}
-                    className="text-sm text-primary-600 hover:text-primary-500 font-medium"
+                    className="text-sm text-steel hover:text-steel-dark font-medium"
                   >
                     Update Payment Method
                   </button>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -218,7 +218,7 @@ export default function Dashboard() {
         />
       ) : (
         <>
-          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-2">
+          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
             {pets.map((pet) => {
               const health = healthData[pet.id];
               const vaccineStatus = health ? getVaccineStatus(health) : null;
@@ -232,7 +232,7 @@ export default function Dashboard() {
                   className="card-interactive fade-in-up no-underline"
                 >
                   <div className="flex gap-4 mb-4">
-                    <div className="flex items-center justify-center flex-shrink-0 w-16 h-16 rounded-full bg-navy overflow-hidden">
+                    <div className="flex items-center justify-center flex-shrink-0 w-16 h-16 rounded-full bg-surface-200 overflow-hidden">
                       {pet.photo_url ? (
                         <img src={pet.photo_url} alt={pet.name} className="w-full h-full object-cover" />
                       ) : (
@@ -277,7 +277,7 @@ export default function Dashboard() {
                       )}
                     </div>
                   </div>
-                  <div className="flex items-center justify-end border-t border-surface-100 pt-3">
+                  <div className="flex items-center justify-end border-t border-surface-100 pt-3 mt-1">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--color-surface-400)">
                       <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
                     </svg>
@@ -290,7 +290,7 @@ export default function Dashboard() {
           {/* Action Items */}
           {actionItems.length > 0 && (
             <div className="dashboard-action-items">
-              <h2 className="text-lg mb-3 text-navy font-semibold">Action Items</h2>
+              <h2 className="section-title mb-3">Action Items</h2>
               {actionItems.map((item, i) => (
                 <Link
                   key={i}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import { cmsApi } from '../api/cms';
 import AddPetModal from '../components/AddPetModal';
 import UpgradeBanner from '../components/UpgradeBanner';
 import SpeciesAvatar from '../components/SpeciesAvatar';
+import EmptyState from '../components/EmptyState';
 
 // Pet limits by tier
 const FREE_TIER_PET_LIMIT = Infinity; // Beta: unlimited pets for all users
@@ -165,7 +166,7 @@ export default function Dashboard() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2" style={{ borderColor: 'var(--color-navy)' }}></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-navy"></div>
       </div>
     );
   }
@@ -178,10 +179,10 @@ export default function Dashboard() {
       </div>
 
       {/* Header */}
-      <div className="flex justify-between items-center" style={{ marginBottom: '24px' }}>
+      <div className="flex justify-between items-center mb-6">
         <div>
-          <h1 className="text-2xl" style={{ color: 'var(--color-navy)', fontWeight: 700 }}>My Pets</h1>
-          <p className="text-sm mt-1" style={{ color: 'var(--color-surface-500)' }}>{getPetCountText()}</p>
+          <h1 className="page-title">My Pets</h1>
+          <p className="text-sm mt-1 text-surface-500">{getPetCountText()}</p>
         </div>
         <button
           onClick={handleAddPetClick}
@@ -201,19 +202,20 @@ export default function Dashboard() {
       )}
 
       {pets.length === 0 ? (
-        <div className="text-center py-12">
-          <div
-            className="mx-auto flex items-center justify-center mb-4"
-            style={{ width: '80px', height: '80px', borderRadius: '50%', background: 'var(--color-navy-50)' }}
-          >
-            <SpeciesAvatar species="other" size={40} />
-          </div>
-          <h3 className="text-lg font-semibold" style={{ color: 'var(--color-navy)' }}>{emptyStateHeading}</h3>
-          <p className="mt-2" style={{ color: 'var(--color-surface-500)' }}>{emptyStateSubheading}</p>
-          <button onClick={() => setShowAddModal(true)} className="mt-4 btn btn-primary">
-            Add Your First Pet
-          </button>
-        </div>
+        <EmptyState
+          icon={
+            <div className="mx-auto flex items-center justify-center w-20 h-20 rounded-full bg-navy-50">
+              <SpeciesAvatar species="other" size={40} />
+            </div>
+          }
+          title={emptyStateHeading}
+          description={emptyStateSubheading || undefined}
+          action={
+            <button onClick={() => setShowAddModal(true)} className="btn btn-primary">
+              Add Your First Pet
+            </button>
+          }
+        />
       ) : (
         <>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-2">
@@ -227,31 +229,24 @@ export default function Dashboard() {
                 <Link
                   key={pet.id}
                   to={`/pets/${pet.id}`}
-                  className="card fade-in-up hover:shadow-lg transition-shadow"
-                  style={{ cursor: 'pointer', textDecoration: 'none' }}
+                  className="card-interactive fade-in-up no-underline"
                 >
-                  <div className="flex gap-4" style={{ marginBottom: '16px' }}>
-                    <div
-                      className="flex items-center justify-center flex-shrink-0"
-                      style={{
-                        width: '64px', height: '64px', borderRadius: '50%',
-                        background: 'var(--color-navy)', overflow: 'hidden',
-                      }}
-                    >
+                  <div className="flex gap-4 mb-4">
+                    <div className="flex items-center justify-center flex-shrink-0 w-16 h-16 rounded-full bg-navy overflow-hidden">
                       {pet.photo_url ? (
                         <img src={pet.photo_url} alt={pet.name} className="w-full h-full object-cover" />
                       ) : (
                         <SpeciesAvatar species={pet.species} size={32} />
                       )}
                     </div>
-                    <div style={{ flex: 1 }}>
-                      <div className="flex items-center gap-2" style={{ marginBottom: '2px' }}>
-                        <h3 className="text-xl" style={{ fontWeight: 600 }}>{pet.name}</h3>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-[2px]">
+                        <h3 className="text-xl font-semibold">{pet.name}</h3>
                         {pet.user_role && pet.user_role !== 'owner' && (
-                          <span className="badge badge-navy" style={{ fontSize: '0.6rem', padding: '2px 6px' }}>Shared with you</span>
+                          <span className="badge badge-navy text-[0.6rem] px-[6px] py-[2px]">Shared with you</span>
                         )}
                       </div>
-                      <p className="text-sm capitalize" style={{ color: 'var(--color-surface-500)' }}>
+                      <p className="text-sm capitalize text-surface-500">
                         {pet.breed ? `${pet.breed}` : pet.species}
                         {pet.date_of_birth && (() => {
                           const born = new Date(pet.date_of_birth!.split('T')[0] + 'T00:00:00');
@@ -274,7 +269,7 @@ export default function Dashboard() {
                             </span>
                           )}
                           {alertCount > 0 && (
-                            <span className="badge badge-danger" style={{ fontSize: '0.6875rem' }}>
+                            <span className="badge badge-danger text-[0.6875rem]">
                               {alertCount} alert{alertCount !== 1 ? 's' : ''} on card
                             </span>
                           )}
@@ -282,7 +277,7 @@ export default function Dashboard() {
                       )}
                     </div>
                   </div>
-                  <div className="flex items-center justify-end" style={{ borderTop: '1px solid var(--color-surface-100)', paddingTop: '12px' }}>
+                  <div className="flex items-center justify-end border-t border-surface-100 pt-3">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--color-surface-400)">
                       <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
                     </svg>
@@ -295,13 +290,12 @@ export default function Dashboard() {
           {/* Action Items */}
           {actionItems.length > 0 && (
             <div className="dashboard-action-items">
-              <h2 className="text-lg mb-3" style={{ color: 'var(--color-navy)', fontWeight: 600 }}>Action Items</h2>
+              <h2 className="text-lg mb-3 text-navy font-semibold">Action Items</h2>
               {actionItems.map((item, i) => (
                 <Link
                   key={i}
                   to={`/pets/${item.petId}/health`}
-                  className={`dashboard-action-item dashboard-action-item-${item.type}`}
-                  style={{ textDecoration: 'none', color: 'inherit' }}
+                  className={`dashboard-action-item dashboard-action-item-${item.type} no-underline text-inherit`}
                 >
                   {item.type === 'danger' ? (
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="var(--color-danger)">

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -26,12 +26,12 @@ export default function ForgotPassword() {
   if (isSubmitted) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-md w-full space-y-8">
+        <div className="max-w-md w-full space-y-8 card">
           <div className="text-center">
             <svg className="mx-auto w-16 h-16 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76" />
             </svg>
-            <h2 className="mt-6 text-3xl font-extrabold text-navy">
+            <h2 className="mt-6 text-3xl font-bold text-navy">
               Check your email
             </h2>
             <p className="mt-4 text-surface-600">
@@ -43,7 +43,7 @@ export default function ForgotPassword() {
           </div>
 
           <div className="space-y-4">
-            <Link to="/login" className="w-full btn-primary py-3 block text-center">
+            <Link to="/login" className="w-full btn btn-primary block text-center">
               Return to sign in
             </Link>
             <button
@@ -63,13 +63,16 @@ export default function ForgotPassword() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+      <div className="max-w-md w-full space-y-8 card">
         <div className="text-center">
-          <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
-            <circle cx="50" cy="50" r="45" />
-            <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
+          <svg width="48" height="48" viewBox="0 0 32 32" fill="none" className="mx-auto">
+            <rect width="32" height="32" rx="10" fill="#1B2A4A"/>
+            <circle cx="11" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="21" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="16" cy="16" r="1.5" fill="#4A7FB5"/>
+            <path d="M9 20c0-3.9 3.1-7 7-7s7 3.1 7 7" stroke="#4A7FB5" strokeWidth="2" strokeLinecap="round"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-navy">
+          <h2 className="mt-6 text-3xl font-bold text-navy">
             Reset your password
           </h2>
           <p className="mt-2 text-sm text-surface-600">
@@ -102,14 +105,14 @@ export default function ForgotPassword() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full btn-primary py-3"
+            className="w-full btn btn-primary"
           >
             {isLoading ? 'Sending...' : 'Send reset link'}
           </button>
 
           <p className="text-center text-sm text-surface-600">
             Remember your password?{' '}
-            <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
+            <Link to="/login" className="text-steel hover:text-steel-dark font-medium">
               Sign in
             </Link>
           </p>

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -25,19 +25,19 @@ export default function ForgotPassword() {
 
   if (isSubmitted) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div className="text-center">
-            <svg className="mx-auto w-16 h-16 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="mx-auto w-16 h-16 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76" />
             </svg>
-            <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+            <h2 className="mt-6 text-3xl font-extrabold text-navy">
               Check your email
             </h2>
-            <p className="mt-4 text-gray-600">
+            <p className="mt-4 text-surface-600">
               If an account exists for <span className="font-medium">{email}</span>, you'll receive a password reset link shortly.
             </p>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="mt-2 text-sm text-surface-500">
               Don't see it? Check your spam folder.
             </p>
           </div>
@@ -62,24 +62,24 @@ export default function ForgotPassword() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
             <circle cx="50" cy="50" r="45" />
             <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-3xl font-extrabold text-navy">
             Reset your password
           </h2>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-surface-600">
             Enter your email and we'll send you a link to reset your password
           </p>
         </div>
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -107,7 +107,7 @@ export default function ForgotPassword() {
             {isLoading ? 'Sending...' : 'Send reset link'}
           </button>
 
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-surface-600">
             Remember your password?{' '}
             <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
               Sign in

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -64,7 +64,7 @@ export default function Homepage() {
         </div>
       ) : error ? (
         <div className="py-20 text-center max-w-md mx-auto px-4">
-          <p className="text-gray-600 mb-4">Some content couldn't be loaded.</p>
+          <p className="text-surface-600 mb-4">Some content couldn't be loaded.</p>
           <button
             onClick={() => window.location.reload()}
             className="btn-primary px-6 py-2"
@@ -83,9 +83,9 @@ export default function Homepage() {
 
       {/* Fallback footer if no CMS footer block */}
       {!footerContent && (
-        <footer className="bg-gray-900 py-8">
+        <footer className="bg-navy py-8">
           <div className="max-w-7xl mx-auto px-4 text-center">
-            <p className="text-gray-400 text-sm">
+            <p className="text-surface-400 text-sm">
               {new Date().getFullYear()} FureverCare. All rights reserved.
             </p>
           </div>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -27,13 +27,16 @@ export default function Login() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+      <div className="max-w-md w-full space-y-8 card">
         <div className="text-center">
-          <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
-            <circle cx="50" cy="50" r="45" />
-            <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
+          <svg width="48" height="48" viewBox="0 0 32 32" fill="none" className="mx-auto">
+            <rect width="32" height="32" rx="10" fill="#1B2A4A"/>
+            <circle cx="11" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="21" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="16" cy="16" r="1.5" fill="#4A7FB5"/>
+            <path d="M9 20c0-3.9 3.1-7 7-7s7 3.1 7 7" stroke="#4A7FB5" strokeWidth="2" strokeLinecap="round"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-navy">
+          <h2 className="mt-6 text-3xl font-bold text-navy">
             Sign in to FureverCare
           </h2>
           <p className="mt-2 text-sm text-surface-600">
@@ -81,7 +84,7 @@ export default function Login() {
           </div>
 
           <div className="flex items-center justify-end">
-            <Link to="/forgot-password" className="text-sm text-primary-600 hover:text-primary-500">
+            <Link to="/forgot-password" className="text-sm text-steel hover:text-steel-dark">
               Forgot your password?
             </Link>
           </div>
@@ -89,14 +92,14 @@ export default function Login() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full btn-primary py-3"
+            className="w-full btn btn-primary"
           >
             {isLoading ? 'Signing in...' : 'Sign in'}
           </button>
 
           <p className="text-center text-sm text-surface-600">
             Don't have an account?{' '}
-            <Link to="/register" className="text-primary-600 hover:text-primary-500 font-medium">
+            <Link to="/register" className="text-steel hover:text-steel-dark font-medium">
               Sign up
             </Link>
           </p>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -26,24 +26,24 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
             <circle cx="50" cy="50" r="45" />
             <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-3xl font-extrabold text-navy">
             Sign in to FureverCare
           </h2>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-surface-600">
             Keep your pet's health info safe and shareable
           </p>
         </div>
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -94,7 +94,7 @@ export default function Login() {
             {isLoading ? 'Signing in...' : 'Sign in'}
           </button>
 
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-surface-600">
             Don't have an account?{' '}
             <Link to="/register" className="text-primary-600 hover:text-primary-500 font-medium">
               Sign up

--- a/frontend/src/pages/Payment.tsx
+++ b/frontend/src/pages/Payment.tsx
@@ -15,8 +15,8 @@ export default function Payment() {
 
   return (
     <div className="max-w-lg mx-auto py-8">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Complete your payment</h1>
-      <p className="text-gray-600 mb-8">
+      <h1 className="text-2xl font-bold text-navy mb-2">Complete your payment</h1>
+      <p className="text-surface-600 mb-8">
         Enter your payment details below. Your information is secured by Stripe.
       </p>
 

--- a/frontend/src/pages/PaymentConfirm.tsx
+++ b/frontend/src/pages/PaymentConfirm.tsx
@@ -76,13 +76,13 @@ export default function PaymentConfirm() {
       <div className="card">
         {status === 'succeeded' && (
           <>
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div className="w-16 h-16 bg-success-light rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">Welcome to Premium!</h1>
-            <p className="text-gray-600 mb-6">{message}</p>
+            <h1 className="text-2xl font-bold text-navy mb-2">Welcome to Premium!</h1>
+            <p className="text-surface-600 mb-6">{message}</p>
             <button onClick={() => navigate('/dashboard')} className="btn-primary">
               Go to Dashboard
             </button>
@@ -91,11 +91,11 @@ export default function PaymentConfirm() {
 
         {status === 'processing' && (
           <>
-            <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <div className="w-16 h-16 bg-info-light rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-info"></div>
             </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">Processing Payment</h1>
-            <p className="text-gray-600 mb-6">{message}</p>
+            <h1 className="text-2xl font-bold text-navy mb-2">Processing Payment</h1>
+            <p className="text-surface-600 mb-6">{message}</p>
             <button onClick={() => navigate('/dashboard')} className="btn-secondary">
               Go to Dashboard
             </button>
@@ -104,13 +104,13 @@ export default function PaymentConfirm() {
 
         {status === 'failed' && (
           <>
-            <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div className="w-16 h-16 bg-danger-light rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-danger" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">Payment Failed</h1>
-            <p className="text-gray-600 mb-6">{message}</p>
+            <h1 className="text-2xl font-bold text-navy mb-2">Payment Failed</h1>
+            <p className="text-surface-600 mb-6">{message}</p>
             <Link to="/pricing" className="btn-accent inline-block">
               Try Again
             </Link>

--- a/frontend/src/pages/PaymentConfirm.tsx
+++ b/frontend/src/pages/PaymentConfirm.tsx
@@ -66,7 +66,7 @@ export default function PaymentConfirm() {
   if (status === 'loading') {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-navy"></div>
       </div>
     );
   }

--- a/frontend/src/pages/PetDetail.tsx
+++ b/frontend/src/pages/PetDetail.tsx
@@ -195,7 +195,7 @@ export default function PetDetail() {
               species={pet.species}
             />
             <div>
-              <h1 className="text-2xl text-navy font-bold">{pet.name}</h1>
+              <h1 className="text-2xl text-navy font-semibold">{pet.name}</h1>
               <p className="capitalize text-surface-500">
                 {pet.breed ? `${pet.breed} ${pet.species}` : pet.species}
                 {pet.sex && ` \u2022 ${pet.sex}${pet.is_fixed ? ' (Fixed)' : ''}`}

--- a/frontend/src/pages/PetDetail.tsx
+++ b/frontend/src/pages/PetDetail.tsx
@@ -118,7 +118,7 @@ export default function PetDetail() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2" style={{ borderColor: 'var(--color-navy)' }}></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-navy"></div>
       </div>
     );
   }
@@ -195,36 +195,35 @@ export default function PetDetail() {
               species={pet.species}
             />
             <div>
-              <h1 className="text-2xl" style={{ color: 'var(--color-navy)', fontWeight: 700 }}>{pet.name}</h1>
-              <p className="capitalize" style={{ color: 'var(--color-surface-500)' }}>
+              <h1 className="text-2xl text-navy font-bold">{pet.name}</h1>
+              <p className="capitalize text-surface-500">
                 {pet.breed ? `${pet.breed} ${pet.species}` : pet.species}
                 {pet.sex && ` \u2022 ${pet.sex}${pet.is_fixed ? ' (Fixed)' : ''}`}
               </p>
-              {pet.weight_kg && <p className="text-sm" style={{ color: 'var(--color-surface-400)' }}>{formatWeight(pet.weight_kg, pet.weight_unit)}</p>}
+              {pet.weight_kg && <p className="text-sm text-surface-400">{formatWeight(pet.weight_kg, pet.weight_unit)}</p>}
             </div>
           </div>
 
           <div className="flex gap-2">
             <button
               onClick={() => setShowAccessModal(true)}
-              className={`btn btn-ghost btn-sm ${!isPremium ? 'opacity-50' : ''}`}
-              title={!isPremium ? 'Premium feature - Upgrade to share pet access with others' : undefined}
-              style={{ border: '1px solid var(--color-surface-200)' }}
+              className={`btn btn-ghost btn-sm border border-surface-200 ${!isPremium ? 'opacity-50' : ''}`}
+              title={!isPremium ? 'Premium feature - Upgrade to share pet access with others' : 'Share Profile'}
             >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'inline', marginRight: '6px', verticalAlign: 'middle' }}>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="inline sm:mr-[6px] align-middle">
                 <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" /><line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
               </svg>
-              Share Profile
+              <span className="hidden sm:inline">Share Profile</span>
             </button>
             <button
               onClick={() => setShowShareModal(true)}
-              className="btn btn-ghost btn-sm"
-              style={{ border: '1px solid var(--color-surface-200)' }}
+              className="btn btn-ghost btn-sm border border-surface-200"
+              title="Send Card"
             >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ display: 'inline', marginRight: '6px', verticalAlign: 'middle' }}>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="inline sm:mr-[6px] align-middle">
                 <line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" />
               </svg>
-              Send Card
+              <span className="hidden sm:inline">Send Card</span>
             </button>
           </div>
         </div>
@@ -286,9 +285,9 @@ export default function PetDetail() {
         ) : (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
             <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Share Pet Access</h2>
+              <h2 className="text-lg font-semibold text-navy mb-4">Share Pet Access</h2>
               <UpgradeBanner type="feature" feature="shared_ownership" />
-              <p className="text-gray-600 text-sm mt-4">
+              <p className="text-surface-600 text-sm mt-4">
                 With premium, you can invite family members or pet sitters to view and manage your pet's health records.
               </p>
               <button

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -77,7 +77,7 @@ export default function Pricing() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-navy"></div>
       </div>
     );
   }
@@ -117,32 +117,34 @@ export default function Pricing() {
       </div>
 
       {/* Billing Toggle */}
-      <div className="flex justify-center items-center gap-4 mb-8">
-        <button
-          onClick={() => setBillingInterval('monthly')}
-          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-            billingInterval === 'monthly'
-              ? 'bg-navy text-white'
-              : 'bg-surface-100 text-surface-700 hover:bg-surface-200'
-          }`}
-        >
-          Monthly
-        </button>
-        <button
-          onClick={() => setBillingInterval('annual')}
-          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-            billingInterval === 'annual'
-              ? 'bg-navy text-white'
-              : 'bg-surface-100 text-surface-700 hover:bg-surface-200'
-          }`}
-        >
-          Annual
-          {annualSavings > 0 && (
-            <span className="ml-2 text-xs bg-accent-400 text-white px-2 py-0.5 rounded-full">
-              Save ${annualSavings.toFixed(0)}/yr
-            </span>
-          )}
-        </button>
+      <div className="flex justify-center items-center mb-8">
+        <div className="bg-surface-100 rounded-lg p-1 inline-flex gap-1">
+          <button
+            onClick={() => setBillingInterval('monthly')}
+            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+              billingInterval === 'monthly'
+                ? 'bg-white text-navy shadow-token-sm'
+                : 'bg-transparent text-surface-500 hover:text-navy'
+            }`}
+          >
+            Monthly
+          </button>
+          <button
+            onClick={() => setBillingInterval('annual')}
+            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+              billingInterval === 'annual'
+                ? 'bg-white text-navy shadow-token-sm'
+                : 'bg-transparent text-surface-500 hover:text-navy'
+            }`}
+          >
+            Annual
+            {annualSavings > 0 && (
+              <span className="ml-2 text-xs bg-success-light text-success font-semibold px-2 py-0.5 rounded-full">
+                Save ${annualSavings.toFixed(0)}/yr
+              </span>
+            )}
+          </button>
+        </div>
       </div>
 
       {error && (
@@ -205,10 +207,10 @@ export default function Pricing() {
         </div>
 
         {/* Premium Tier */}
-        <div className="card border-2 border-primary-500 relative">
+        <div className="card border-2 border-steel relative">
           {hasActiveSubscription && (
             <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-primary-500 text-white">
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-navy text-white">
                 {isTrialing ? 'Trial Active' : 'Current Plan'}
               </span>
             </div>
@@ -294,7 +296,7 @@ export default function Pricing() {
               {features.map((feature, index) => (
                 <tr
                   key={feature.name}
-                  className={index % 2 === 0 ? 'bg-surface' : 'bg-white'}
+                  className={index % 2 === 0 ? 'bg-surface-100' : 'bg-white'}
                 >
                   <td className="py-4 px-4 text-surface-700">{feature.name}</td>
                   <td className="py-4 px-4 text-center">

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { billingApi, PricingConfig, TrialConfig } from '../api/billing';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/24/solid';
@@ -97,12 +97,20 @@ export default function Pricing() {
 
   return (
     <div className="py-8">
+      <div className="breadcrumb">
+        <Link to="/dashboard">Dashboard</Link>
+        <span className="sep">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+        </span>
+        <span className="current">Pricing</span>
+      </div>
+
       {/* Header */}
       <div className="text-center mb-12">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">
+        <h1 className="text-3xl font-bold text-navy mb-4">
           Simple, Transparent Pricing
         </h1>
-        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+        <p className="text-lg text-surface-600 max-w-2xl mx-auto">
           Keep your pet's health information organized and accessible.
           Start free or upgrade for unlimited features.
         </p>
@@ -114,8 +122,8 @@ export default function Pricing() {
           onClick={() => setBillingInterval('monthly')}
           className={`px-4 py-2 rounded-lg font-medium transition-colors ${
             billingInterval === 'monthly'
-              ? 'bg-primary-500 text-white'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              ? 'bg-navy text-white'
+              : 'bg-surface-100 text-surface-700 hover:bg-surface-200'
           }`}
         >
           Monthly
@@ -124,8 +132,8 @@ export default function Pricing() {
           onClick={() => setBillingInterval('annual')}
           className={`px-4 py-2 rounded-lg font-medium transition-colors ${
             billingInterval === 'annual'
-              ? 'bg-primary-500 text-white'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              ? 'bg-navy text-white'
+              : 'bg-surface-100 text-surface-700 hover:bg-surface-200'
           }`}
         >
           Annual
@@ -139,7 +147,7 @@ export default function Pricing() {
 
       {error && (
         <div className="max-w-3xl mx-auto mb-6">
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+          <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
             {error}
           </div>
         </div>
@@ -148,30 +156,30 @@ export default function Pricing() {
       {/* Pricing Cards */}
       <div className="max-w-4xl mx-auto grid gap-8 md:grid-cols-2">
         {/* Free Tier */}
-        <div className="card border-2 border-gray-200 relative">
+        <div className="card border-2 border-surface-200 relative">
           <div className="text-center mb-6">
-            <h2 className="text-xl font-bold text-gray-900 mb-2">Free</h2>
-            <div className="text-4xl font-bold text-gray-900">
+            <h2 className="text-xl font-bold text-navy mb-2">Free</h2>
+            <div className="text-4xl font-bold text-navy">
               $0
-              <span className="text-lg font-normal text-gray-500">/mo</span>
+              <span className="text-lg font-normal text-surface-500">/mo</span>
             </div>
-            <p className="text-gray-500 mt-2">Perfect for getting started</p>
+            <p className="text-surface-500 mt-2">Perfect for getting started</p>
           </div>
 
           <ul className="space-y-3 mb-8">
             {features.map((feature) => (
               <li key={feature.name} className="flex items-center gap-3">
                 {feature.free === true ? (
-                  <CheckIcon className="w-5 h-5 text-green-500 flex-shrink-0" />
+                  <CheckIcon className="w-5 h-5 text-success flex-shrink-0" />
                 ) : feature.free === false ? (
-                  <XMarkIcon className="w-5 h-5 text-gray-300 flex-shrink-0" />
+                  <XMarkIcon className="w-5 h-5 text-surface-300 flex-shrink-0" />
                 ) : (
-                  <CheckIcon className="w-5 h-5 text-green-500 flex-shrink-0" />
+                  <CheckIcon className="w-5 h-5 text-success flex-shrink-0" />
                 )}
-                <span className={feature.free === false ? 'text-gray-400' : 'text-gray-700'}>
+                <span className={feature.free === false ? 'text-surface-400' : 'text-surface-700'}>
                   {feature.name}
                   {typeof feature.free === 'string' && (
-                    <span className="text-gray-500 ml-1">({feature.free})</span>
+                    <span className="text-surface-500 ml-1">({feature.free})</span>
                   )}
                 </span>
               </li>
@@ -180,7 +188,7 @@ export default function Pricing() {
 
           {user && !isPremium && (
             <div className="text-center">
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-700">
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-surface-100 text-surface-700">
                 Current Plan
               </span>
             </div>
@@ -207,14 +215,14 @@ export default function Pricing() {
           )}
 
           <div className="text-center mb-6">
-            <h2 className="text-xl font-bold text-gray-900 mb-2">Premium</h2>
-            <div className="text-4xl font-bold text-gray-900">
+            <h2 className="text-xl font-bold text-navy mb-2">Premium</h2>
+            <div className="text-4xl font-bold text-navy">
               {formatPrice(currentPrice)}
-              <span className="text-lg font-normal text-gray-500">
+              <span className="text-lg font-normal text-surface-500">
                 /{billingInterval === 'monthly' ? 'mo' : 'yr'}
               </span>
             </div>
-            <p className="text-gray-500 mt-2">
+            <p className="text-surface-500 mt-2">
               {trialConfig && trialConfig.trial_days > 0
                 ? `${trialConfig.trial_days}-day free trial included`
                 : 'For serious pet parents'}
@@ -224,8 +232,8 @@ export default function Pricing() {
           <ul className="space-y-3 mb-8">
             {features.map((feature) => (
               <li key={feature.name} className="flex items-center gap-3">
-                <CheckIcon className="w-5 h-5 text-green-500 flex-shrink-0" />
-                <span className="text-gray-700">
+                <CheckIcon className="w-5 h-5 text-success flex-shrink-0" />
+                <span className="text-surface-700">
                   {feature.name}
                   {typeof feature.premium === 'string' && (
                     <span className="text-primary-600 font-medium ml-1">
@@ -269,38 +277,38 @@ export default function Pricing() {
 
       {/* Feature Comparison Table */}
       <div className="max-w-4xl mx-auto mt-16">
-        <h2 className="text-2xl font-bold text-gray-900 text-center mb-8">
+        <h2 className="text-2xl font-bold text-navy text-center mb-8">
           Compare Features
         </h2>
 
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b-2 border-gray-200">
-                <th className="text-left py-4 px-4 font-semibold text-gray-900">Feature</th>
-                <th className="text-center py-4 px-4 font-semibold text-gray-900">Free</th>
-                <th className="text-center py-4 px-4 font-semibold text-gray-900">Premium</th>
+              <tr className="border-b-2 border-surface-200">
+                <th className="text-left py-4 px-4 font-semibold text-navy">Feature</th>
+                <th className="text-center py-4 px-4 font-semibold text-navy">Free</th>
+                <th className="text-center py-4 px-4 font-semibold text-navy">Premium</th>
               </tr>
             </thead>
             <tbody>
               {features.map((feature, index) => (
                 <tr
                   key={feature.name}
-                  className={index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}
+                  className={index % 2 === 0 ? 'bg-surface' : 'bg-white'}
                 >
-                  <td className="py-4 px-4 text-gray-700">{feature.name}</td>
+                  <td className="py-4 px-4 text-surface-700">{feature.name}</td>
                   <td className="py-4 px-4 text-center">
                     {feature.free === true ? (
-                      <CheckIcon className="w-5 h-5 text-green-500 mx-auto" />
+                      <CheckIcon className="w-5 h-5 text-success mx-auto" />
                     ) : feature.free === false ? (
-                      <XMarkIcon className="w-5 h-5 text-gray-300 mx-auto" />
+                      <XMarkIcon className="w-5 h-5 text-surface-300 mx-auto" />
                     ) : (
-                      <span className="text-gray-700">{feature.free}</span>
+                      <span className="text-surface-700">{feature.free}</span>
                     )}
                   </td>
                   <td className="py-4 px-4 text-center">
                     {feature.premium === true ? (
-                      <CheckIcon className="w-5 h-5 text-green-500 mx-auto" />
+                      <CheckIcon className="w-5 h-5 text-success mx-auto" />
                     ) : (
                       <span className="text-primary-600 font-medium">{feature.premium}</span>
                     )}
@@ -314,10 +322,10 @@ export default function Pricing() {
 
       {/* FAQ or Additional Info */}
       <div className="max-w-2xl mx-auto mt-16 text-center">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        <h3 className="text-lg font-semibold text-navy mb-4">
           Questions about our plans?
         </h3>
-        <p className="text-gray-600">
+        <p className="text-surface-600">
           All plans include access to our mobile-friendly emergency health cards.
           Premium users can cancel anytime from their billing portal.
         </p>

--- a/frontend/src/pages/PublicCard.tsx
+++ b/frontend/src/pages/PublicCard.tsx
@@ -28,7 +28,7 @@ export default function PublicCard() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-surface flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-navy"></div>
       </div>
     );
   }

--- a/frontend/src/pages/PublicCard.tsx
+++ b/frontend/src/pages/PublicCard.tsx
@@ -27,7 +27,7 @@ export default function PublicCard() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-surface flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
       </div>
     );
@@ -35,13 +35,13 @@ export default function PublicCard() {
 
   if (error || !card) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-surface flex items-center justify-center p-4">
         <div className="text-center">
-          <svg className="mx-auto w-16 h-16 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="mx-auto w-16 h-16 text-surface-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M12 2a10 10 0 110 20 10 10 0 010-20z" />
           </svg>
-          <h1 className="mt-4 text-xl font-semibold text-gray-900">Card Not Found</h1>
-          <p className="mt-2 text-gray-500">{error}</p>
+          <h1 className="mt-4 text-xl font-semibold text-navy">Card Not Found</h1>
+          <p className="mt-2 text-surface-500">{error}</p>
           <Link to="/" className="mt-4 inline-block btn-primary">
             Go to FureverCare
           </Link>

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -41,13 +41,16 @@ export default function Register() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+      <div className="max-w-md w-full space-y-8 card">
         <div className="text-center">
-          <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
-            <circle cx="50" cy="50" r="45" />
-            <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
+          <svg width="48" height="48" viewBox="0 0 32 32" fill="none" className="mx-auto">
+            <rect width="32" height="32" rx="10" fill="#1B2A4A"/>
+            <circle cx="11" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="21" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="16" cy="16" r="1.5" fill="#4A7FB5"/>
+            <path d="M9 20c0-3.9 3.1-7 7-7s7 3.1 7 7" stroke="#4A7FB5" strokeWidth="2" strokeLinecap="round"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-navy">
+          <h2 className="mt-6 text-3xl font-bold text-navy">
             Create your account
           </h2>
           <p className="mt-2 text-sm text-surface-600">
@@ -137,14 +140,14 @@ export default function Register() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full btn-primary py-3"
+            className="w-full btn btn-primary"
           >
             {isLoading ? 'Creating account...' : 'Create account'}
           </button>
 
           <p className="text-center text-sm text-surface-600">
             Already have an account?{' '}
-            <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
+            <Link to="/login" className="text-steel hover:text-steel-dark font-medium">
               Sign in
             </Link>
           </p>

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -40,24 +40,24 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
             <circle cx="50" cy="50" r="45" />
             <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-3xl font-extrabold text-navy">
             Create your account
           </h2>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-surface-600">
             Start protecting your pet's health information today
           </p>
         </div>
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -142,7 +142,7 @@ export default function Register() {
             {isLoading ? 'Creating account...' : 'Create account'}
           </button>
 
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-surface-600">
             Already have an account?{' '}
             <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
               Sign in

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -66,7 +66,7 @@ export default function ResetPassword() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4">
         <div className="text-center">
-          <svg className="animate-spin mx-auto h-12 w-12 text-primary-600" fill="none" viewBox="0 0 24 24">
+          <svg className="animate-spin mx-auto h-12 w-12 text-navy" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
@@ -79,12 +79,12 @@ export default function ResetPassword() {
   if (!isTokenValid) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-md w-full space-y-8">
+        <div className="max-w-md w-full space-y-8 card">
           <div className="text-center">
             <svg className="mx-auto w-16 h-16 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
-            <h2 className="mt-6 text-3xl font-extrabold text-navy">
+            <h2 className="mt-6 text-3xl font-bold text-navy">
               Invalid or expired link
             </h2>
             <p className="mt-4 text-surface-600">
@@ -93,7 +93,7 @@ export default function ResetPassword() {
           </div>
 
           <div className="space-y-4">
-            <Link to="/forgot-password" className="w-full btn-primary py-3 block text-center">
+            <Link to="/forgot-password" className="w-full btn btn-primary block text-center">
               Request new reset link
             </Link>
             <Link to="/login" className="w-full btn-secondary py-3 block text-center">
@@ -107,13 +107,16 @@ export default function ResetPassword() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
+      <div className="max-w-md w-full space-y-8 card">
         <div className="text-center">
-          <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
-            <circle cx="50" cy="50" r="45" />
-            <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
+          <svg width="48" height="48" viewBox="0 0 32 32" fill="none" className="mx-auto">
+            <rect width="32" height="32" rx="10" fill="#1B2A4A"/>
+            <circle cx="11" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="21" cy="12" r="2" fill="#4A7FB5"/>
+            <circle cx="16" cy="16" r="1.5" fill="#4A7FB5"/>
+            <path d="M9 20c0-3.9 3.1-7 7-7s7 3.1 7 7" stroke="#4A7FB5" strokeWidth="2" strokeLinecap="round"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-navy">
+          <h2 className="mt-6 text-3xl font-bold text-navy">
             Create new password
           </h2>
           <p className="mt-2 text-sm text-surface-600">
@@ -165,14 +168,14 @@ export default function ResetPassword() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full btn-primary py-3"
+            className="w-full btn btn-primary"
           >
             {isLoading ? 'Resetting...' : 'Reset password'}
           </button>
 
           <p className="text-center text-sm text-surface-600">
             Remember your password?{' '}
-            <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
+            <Link to="/login" className="text-steel hover:text-steel-dark font-medium">
               Sign in
             </Link>
           </p>

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -64,13 +64,13 @@ export default function ResetPassword() {
 
   if (isValidating) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+      <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4">
         <div className="text-center">
           <svg className="animate-spin mx-auto h-12 w-12 text-primary-600" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
-          <p className="mt-4 text-gray-600">Validating reset link...</p>
+          <p className="mt-4 text-surface-600">Validating reset link...</p>
         </div>
       </div>
     );
@@ -78,16 +78,16 @@ export default function ResetPassword() {
 
   if (!isTokenValid) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div className="text-center">
-            <svg className="mx-auto w-16 h-16 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="mx-auto w-16 h-16 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
-            <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+            <h2 className="mt-6 text-3xl font-extrabold text-navy">
               Invalid or expired link
             </h2>
-            <p className="mt-4 text-gray-600">
+            <p className="mt-4 text-surface-600">
               This password reset link is invalid or has expired. Please request a new one.
             </p>
           </div>
@@ -106,24 +106,24 @@ export default function ResetPassword() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-surface py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <svg className="mx-auto w-16 h-16 text-primary-600" viewBox="0 0 100 100" fill="currentColor">
             <circle cx="50" cy="50" r="45" />
             <path d="M30 35 Q35 25 45 30 Q50 20 55 30 Q65 25 70 35 Q75 45 65 50 Q70 60 60 65 Q55 75 50 70 Q45 75 40 65 Q30 60 35 50 Q25 45 30 35" fill="white"/>
           </svg>
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-3xl font-extrabold text-navy">
             Create new password
           </h2>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm text-surface-600">
             Enter your new password below
           </p>
         </div>
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -170,7 +170,7 @@ export default function ResetPassword() {
             {isLoading ? 'Resetting...' : 'Reset password'}
           </button>
 
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-surface-600">
             Remember your password?{' '}
             <Link to="/login" className="text-primary-600 hover:text-primary-500 font-medium">
               Sign in

--- a/frontend/src/pages/TokenCard.tsx
+++ b/frontend/src/pages/TokenCard.tsx
@@ -79,7 +79,7 @@ export default function TokenCard() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-surface flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-navy"></div>
       </div>
     );
   }

--- a/frontend/src/pages/TokenCard.tsx
+++ b/frontend/src/pages/TokenCard.tsx
@@ -78,7 +78,7 @@ export default function TokenCard() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-surface flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
       </div>
     );
@@ -86,15 +86,15 @@ export default function TokenCard() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-surface flex items-center justify-center p-4">
         <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full text-center">
-          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg className="w-8 h-8 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <div className="w-16 h-16 bg-danger-light rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-danger" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
           </div>
-          <h1 className="text-xl font-bold text-gray-900 mb-2">Link Unavailable</h1>
-          <p className="text-gray-600">{error}</p>
+          <h1 className="text-xl font-bold text-navy mb-2">Link Unavailable</h1>
+          <p className="text-surface-600">{error}</p>
         </div>
       </div>
     );
@@ -103,16 +103,16 @@ export default function TokenCard() {
   // PIN entry form
   if (tokenInfo?.requires_pin && !card) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-surface flex items-center justify-center p-4">
         <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full">
           <div className="text-center mb-6">
-            <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div className="w-16 h-16 bg-info-light rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
               </svg>
             </div>
-            <h1 className="text-xl font-bold text-gray-900 mb-2">PIN Required</h1>
-            <p className="text-gray-600">
+            <h1 className="text-xl font-bold text-navy mb-2">PIN Required</h1>
+            <p className="text-surface-600">
               {tokenInfo.label ? `Access to "${tokenInfo.label}"` : 'This share link'} requires a PIN.
             </p>
           </div>
@@ -124,13 +124,13 @@ export default function TokenCard() {
                 value={pin}
                 onChange={e => setPin(e.target.value)}
                 placeholder="Enter PIN"
-                className={`input text-center text-lg tracking-widest ${isPinError ? 'border-red-500' : ''}`}
+                className={`input text-center text-lg tracking-widest ${isPinError ? 'border-danger' : ''}`}
                 autoFocus
                 minLength={4}
                 maxLength={20}
               />
               {isPinError && (
-                <p className="text-red-600 text-sm mt-1 text-center">Invalid PIN. Please try again.</p>
+                <p className="text-danger text-sm mt-1 text-center">Invalid PIN. Please try again.</p>
               )}
             </div>
             <button
@@ -143,7 +143,7 @@ export default function TokenCard() {
           </form>
 
           {tokenInfo.expires_at && (
-            <p className="text-xs text-gray-400 text-center mt-4">
+            <p className="text-xs text-surface-400 text-center mt-4">
               Link expires: {new Date(tokenInfo.expires_at).toLocaleString()}
             </p>
           )}

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -18,7 +18,7 @@ export default function AdminLayout() {
   const closeSidebar = () => setSidebarOpen(false);
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
+    <div className="min-h-screen bg-surface flex">
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -154,7 +154,7 @@ export default function AdminLayout() {
               {/* Hamburger menu button for mobile */}
               <button
                 onClick={() => setSidebarOpen(true)}
-                className="lg:hidden p-2 rounded-lg text-gray-600 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                className="lg:hidden p-2 rounded-lg text-surface-600 hover:text-navy hover:bg-surface-100 transition-colors"
                 aria-label="Open sidebar"
               >
                 <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -166,10 +166,10 @@ export default function AdminLayout() {
               </span>
             </div>
             <div className="flex items-center space-x-2 sm:space-x-4">
-              <span className="text-gray-600 text-sm sm:text-base hidden sm:inline">Hi, {user?.name}</span>
+              <span className="text-surface-600 text-sm sm:text-base hidden sm:inline">Hi, {user?.name}</span>
               <button
                 onClick={handleLogout}
-                className="text-gray-600 hover:text-gray-900 text-sm sm:text-base"
+                className="text-surface-600 hover:text-navy text-sm sm:text-base"
               >
                 Logout
               </button>

--- a/frontend/src/pages/admin/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/admin/AnalyticsDashboard.tsx
@@ -45,7 +45,7 @@ export default function AnalyticsDashboard() {
   if (error) {
     return (
       <div className="max-w-7xl mx-auto">
-        <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+        <div className="bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
           {error}
         </div>
       </div>
@@ -56,8 +56,8 @@ export default function AnalyticsDashboard() {
     <div className="max-w-7xl mx-auto">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">Analytics Dashboard</h1>
-        <p className="text-gray-600 mt-1">Platform metrics and insights</p>
+        <h1 className="text-2xl font-bold text-navy">Analytics Dashboard</h1>
+        <p className="text-surface-600 mt-1">Platform metrics and insights</p>
       </div>
 
       {/* Overview Cards */}
@@ -66,11 +66,11 @@ export default function AnalyticsDashboard() {
           <div className="bg-white rounded-lg shadow-sm p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Total Users</p>
-                <p className="text-3xl font-bold text-gray-900 mt-2">{overview.total_users.toLocaleString()}</p>
+                <p className="text-sm font-medium text-surface-600">Total Users</p>
+                <p className="text-3xl font-bold text-navy mt-2">{overview.total_users.toLocaleString()}</p>
               </div>
-              <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
-                <svg className="w-6 h-6 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="w-12 h-12 bg-info-light rounded-lg flex items-center justify-center">
+                <svg className="w-6 h-6 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
                 </svg>
               </div>
@@ -80,11 +80,11 @@ export default function AnalyticsDashboard() {
           <div className="bg-white rounded-lg shadow-sm p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Total Pets</p>
-                <p className="text-3xl font-bold text-gray-900 mt-2">{overview.total_pets.toLocaleString()}</p>
+                <p className="text-sm font-medium text-surface-600">Total Pets</p>
+                <p className="text-3xl font-bold text-navy mt-2">{overview.total_pets.toLocaleString()}</p>
               </div>
-              <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
-                <svg className="w-6 h-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="w-12 h-12 bg-success-light rounded-lg flex items-center justify-center">
+                <svg className="w-6 h-6 text-success" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
               </div>
@@ -94,8 +94,8 @@ export default function AnalyticsDashboard() {
           <div className="bg-white rounded-lg shadow-sm p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">New Users (7d)</p>
-                <p className="text-3xl font-bold text-gray-900 mt-2">{overview.new_users_this_week.toLocaleString()}</p>
+                <p className="text-sm font-medium text-surface-600">New Users (7d)</p>
+                <p className="text-3xl font-bold text-navy mt-2">{overview.new_users_this_week.toLocaleString()}</p>
               </div>
               <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center">
                 <svg className="w-6 h-6 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -108,8 +108,8 @@ export default function AnalyticsDashboard() {
           <div className="bg-white rounded-lg shadow-sm p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">New Pets (7d)</p>
-                <p className="text-3xl font-bold text-gray-900 mt-2">{overview.new_pets_this_week.toLocaleString()}</p>
+                <p className="text-sm font-medium text-surface-600">New Pets (7d)</p>
+                <p className="text-3xl font-bold text-navy mt-2">{overview.new_pets_this_week.toLocaleString()}</p>
               </div>
               <div className="w-12 h-12 bg-amber-100 rounded-lg flex items-center justify-center">
                 <svg className="w-6 h-6 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -122,8 +122,8 @@ export default function AnalyticsDashboard() {
           <div className="bg-white rounded-lg shadow-sm p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Most Common Species</p>
-                <p className="text-3xl font-bold text-gray-900 mt-2 capitalize">
+                <p className="text-sm font-medium text-surface-600">Most Common Species</p>
+                <p className="text-3xl font-bold text-navy mt-2 capitalize">
                   {overview.most_common_species || 'N/A'}
                 </p>
               </div>
@@ -138,9 +138,9 @@ export default function AnalyticsDashboard() {
           <div className="bg-white rounded-lg shadow-sm p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Adoption Rate</p>
-                <p className="text-3xl font-bold text-gray-900 mt-2">{overview.adoption_rate.toFixed(1)}%</p>
-                <p className="text-xs text-gray-500 mt-1">Users with pets</p>
+                <p className="text-sm font-medium text-surface-600">Adoption Rate</p>
+                <p className="text-3xl font-bold text-navy mt-2">{overview.adoption_rate.toFixed(1)}%</p>
+                <p className="text-xs text-surface-500 mt-1">Users with pets</p>
               </div>
               <div className="w-12 h-12 bg-teal-100 rounded-lg flex items-center justify-center">
                 <svg className="w-6 h-6 text-teal-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -157,58 +157,58 @@ export default function AnalyticsDashboard() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Most Common Conditions */}
           <div className="bg-white rounded-lg shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Most Common Conditions</h2>
+            <h2 className="text-lg font-semibold text-navy mb-4">Most Common Conditions</h2>
             {healthInsights.most_common_conditions.length > 0 ? (
               <div className="space-y-3">
                 {healthInsights.most_common_conditions.map((condition, index) => (
                   <div key={index} className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <span className="text-sm font-medium text-gray-500 w-6">{index + 1}.</span>
-                      <span className="text-sm text-gray-900">{condition.name}</span>
+                      <span className="text-sm font-medium text-surface-500 w-6">{index + 1}.</span>
+                      <span className="text-sm text-navy">{condition.name}</span>
                     </div>
-                    <span className="text-sm font-semibold text-gray-700">{condition.count}</span>
+                    <span className="text-sm font-semibold text-surface-700">{condition.count}</span>
                   </div>
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-gray-500">No conditions recorded</p>
+              <p className="text-sm text-surface-500">No conditions recorded</p>
             )}
           </div>
 
           {/* Most Common Medications */}
           <div className="bg-white rounded-lg shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Most Common Medications</h2>
+            <h2 className="text-lg font-semibold text-navy mb-4">Most Common Medications</h2>
             {healthInsights.most_common_medications.length > 0 ? (
               <div className="space-y-3">
                 {healthInsights.most_common_medications.map((medication, index) => (
                   <div key={index} className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <span className="text-sm font-medium text-gray-500 w-6">{index + 1}.</span>
-                      <span className="text-sm text-gray-900">{medication.name}</span>
+                      <span className="text-sm font-medium text-surface-500 w-6">{index + 1}.</span>
+                      <span className="text-sm text-navy">{medication.name}</span>
                     </div>
-                    <span className="text-sm font-semibold text-gray-700">{medication.count}</span>
+                    <span className="text-sm font-semibold text-surface-700">{medication.count}</span>
                   </div>
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-gray-500">No medications recorded</p>
+              <p className="text-sm text-surface-500">No medications recorded</p>
             )}
           </div>
 
           {/* Allergy and Microchip Stats */}
           <div className="bg-white rounded-lg shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Pet Health Stats</h2>
+            <h2 className="text-lg font-semibold text-navy mb-4">Pet Health Stats</h2>
             <div className="space-y-4">
               <div>
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm text-gray-700">Pets with Allergies</span>
-                  <span className="text-sm font-semibold text-gray-900">
+                  <span className="text-sm text-surface-700">Pets with Allergies</span>
+                  <span className="text-sm font-semibold text-navy">
                     {healthInsights.pets_with_allergies_pct.toFixed(1)}%
                   </span>
                 </div>
-                <div className="w-full bg-gray-200 rounded-full h-2">
+                <div className="w-full bg-surface-200 rounded-full h-2">
                   <div
-                    className="bg-red-600 h-2 rounded-full"
+                    className="bg-danger h-2 rounded-full"
                     style={{ width: `${healthInsights.pets_with_allergies_pct}%` }}
                   ></div>
                 </div>
@@ -216,14 +216,14 @@ export default function AnalyticsDashboard() {
 
               <div>
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm text-gray-700">Pets with Microchips</span>
-                  <span className="text-sm font-semibold text-gray-900">
+                  <span className="text-sm text-surface-700">Pets with Microchips</span>
+                  <span className="text-sm font-semibold text-navy">
                     {healthInsights.pets_with_microchips_pct.toFixed(1)}%
                   </span>
                 </div>
-                <div className="w-full bg-gray-200 rounded-full h-2">
+                <div className="w-full bg-surface-200 rounded-full h-2">
                   <div
-                    className="bg-blue-600 h-2 rounded-full"
+                    className="bg-info h-2 rounded-full"
                     style={{ width: `${healthInsights.pets_with_microchips_pct}%` }}
                   ></div>
                 </div>

--- a/frontend/src/pages/admin/CMSEditor.tsx
+++ b/frontend/src/pages/admin/CMSEditor.tsx
@@ -13,12 +13,12 @@ const BLOCK_TYPE_LABELS: Record<string, string> = {
 };
 
 const BLOCK_TYPE_COLORS: Record<string, string> = {
-  hero: 'bg-blue-100 text-blue-800',
-  features: 'bg-green-100 text-green-800',
-  how_it_works: 'bg-purple-100 text-purple-800',
-  cta: 'bg-orange-100 text-orange-800',
-  footer: 'bg-gray-100 text-gray-800',
-  empty_state: 'bg-amber-100 text-amber-800',
+  hero: 'bg-info-light text-info',
+  features: 'bg-success-light text-success',
+  how_it_works: 'bg-surface-100 text-surface-700',
+  cta: 'bg-warning-light text-warning-dark',
+  footer: 'bg-surface-100 text-navy',
+  empty_state: 'bg-warning-light text-warning-dark',
 };
 
 export default function CMSEditor() {
@@ -139,14 +139,14 @@ export default function CMSEditor() {
     <div className="max-w-5xl mx-auto">
       {/* Page header */}
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">CMS Editor</h1>
-        <p className="text-gray-600 mt-1">Manage your website content</p>
+        <h1 className="text-2xl font-bold text-navy">CMS Editor</h1>
+        <p className="text-surface-600 mt-1">Manage your website content</p>
       </div>
 
       {error && (
-        <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg flex items-center justify-between">
+        <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg flex items-center justify-between">
           <span>{error}</span>
-          <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600">
+          <button onClick={() => setError(null)} className="text-danger hover:text-danger-dark">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -159,7 +159,7 @@ export default function CMSEditor() {
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           {/* Page selector */}
           <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
-            <label className="text-sm font-medium text-gray-700">Page:</label>
+            <label className="text-sm font-medium text-surface-700">Page:</label>
             <select
               value={selectedPageId || ''}
               onChange={(e) => setSelectedPageId(Number(e.target.value))}
@@ -220,14 +220,14 @@ export default function CMSEditor() {
 
         {/* Status indicator */}
         {currentPage && (
-          <div className="mt-3 pt-3 border-t border-gray-100">
+          <div className="mt-3 pt-3 border-t border-surface-100">
             <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-2 text-sm">
               <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium w-fit ${
-                currentPage.is_published ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
+                currentPage.is_published ? 'bg-success-light text-success' : 'bg-surface-100 text-navy'
               }`}>
                 {currentPage.is_published ? 'Published' : 'Draft'}
               </span>
-              <span className="text-gray-500 text-xs sm:text-sm">
+              <span className="text-surface-500 text-xs sm:text-sm">
                 Last updated: {new Date(currentPage.updated_at).toLocaleString()}
               </span>
             </div>
@@ -238,13 +238,13 @@ export default function CMSEditor() {
       {/* Blocks list */}
       {currentPage && (
         <div className="bg-white rounded-lg shadow-sm">
-          <div className="px-4 py-3 border-b border-gray-100">
-            <h2 className="text-lg font-medium text-gray-900">Content Blocks</h2>
+          <div className="px-4 py-3 border-b border-surface-100">
+            <h2 className="text-lg font-medium text-navy">Content Blocks</h2>
           </div>
 
-          <div className="divide-y divide-gray-100">
+          <div className="divide-y divide-surface-100">
             {currentPage.blocks.length === 0 ? (
-              <div className="p-8 text-center text-gray-500">
+              <div className="p-8 text-center text-surface-500">
                 No blocks found. Add blocks to start editing content.
               </div>
             ) : (
@@ -252,20 +252,20 @@ export default function CMSEditor() {
                 <div
                   key={block.id}
                   className={`p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 ${
-                    !block.is_visible ? 'bg-gray-50 opacity-60' : ''
+                    !block.is_visible ? 'bg-surface opacity-60' : ''
                   }`}
                 >
                   <div className="flex items-center space-x-4">
-                    <span className="text-gray-400 font-mono text-sm">
+                    <span className="text-surface-400 font-mono text-sm">
                       {String(block.sort_order + 1).padStart(2, '0')}
                     </span>
                     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium ${
-                      BLOCK_TYPE_COLORS[block.block_type] || 'bg-gray-100 text-gray-800'
+                      BLOCK_TYPE_COLORS[block.block_type] || 'bg-surface-100 text-navy'
                     }`}>
                       {BLOCK_TYPE_LABELS[block.block_type] || block.block_type}
                     </span>
                     {!block.is_visible && (
-                      <span className="text-xs text-gray-500">(hidden)</span>
+                      <span className="text-xs text-surface-500">(hidden)</span>
                     )}
                   </div>
 
@@ -274,8 +274,8 @@ export default function CMSEditor() {
                       onClick={() => handleToggleBlockVisibility(block)}
                       className={`p-2 rounded-lg transition-colors ${
                         block.is_visible
-                          ? 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
-                          : 'text-gray-400 hover:text-primary-600 hover:bg-primary-50'
+                          ? 'text-surface-400 hover:text-surface-600 hover:bg-surface-100'
+                          : 'text-surface-400 hover:text-primary-600 hover:bg-primary-50'
                       }`}
                       title={block.is_visible ? 'Hide block' : 'Show block'}
                     >

--- a/frontend/src/pages/admin/PetDetailModal.tsx
+++ b/frontend/src/pages/admin/PetDetailModal.tsx
@@ -64,14 +64,14 @@ export default function PetDetailModal({ petId, onClose }: Props) {
           {/* Header */}
           <div className="flex justify-between items-start mb-6">
             <div>
-              <h2 className="text-2xl font-bold text-gray-900">Pet Details</h2>
+              <h2 className="text-2xl font-bold text-navy">Pet Details</h2>
               {pet && (
-                <p className="text-sm text-gray-500 mt-1">ID: {pet.id}</p>
+                <p className="text-sm text-surface-500 mt-1">ID: {pet.id}</p>
               )}
             </div>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-surface-400 hover:text-surface-600 transition-colors"
             >
               <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -80,7 +80,7 @@ export default function PetDetailModal({ petId, onClose }: Props) {
           </div>
 
           {error && (
-            <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -92,7 +92,7 @@ export default function PetDetailModal({ petId, onClose }: Props) {
           ) : pet ? (
             <div className="space-y-6">
               {/* Pet Info */}
-              <div className="bg-gray-50 rounded-lg p-4">
+              <div className="bg-surface rounded-lg p-4">
                 <div className="flex items-start space-x-4">
                   <div className="w-20 h-20 bg-primary-100 rounded-full flex items-center justify-center overflow-hidden flex-shrink-0">
                     {pet.photo_url ? (
@@ -108,35 +108,35 @@ export default function PetDetailModal({ petId, onClose }: Props) {
                     )}
                   </div>
                   <div className="flex-1">
-                    <h3 className="text-xl font-bold text-gray-900">{pet.name}</h3>
-                    <p className="text-gray-600 capitalize">
+                    <h3 className="text-xl font-bold text-navy">{pet.name}</h3>
+                    <p className="text-surface-600 capitalize">
                       {pet.breed ? `${pet.breed} ${pet.species}` : pet.species}
                     </p>
                     <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
                       {pet.date_of_birth && (
                         <div>
-                          <span className="text-gray-500">DOB:</span>
-                          <span className="ml-1 text-gray-900">
+                          <span className="text-surface-500">DOB:</span>
+                          <span className="ml-1 text-navy">
                             {new Date(pet.date_of_birth.split('T')[0] + 'T00:00:00').toLocaleDateString()}
                           </span>
                         </div>
                       )}
                       {pet.sex && (
                         <div>
-                          <span className="text-gray-500">Sex:</span>
-                          <span className="ml-1 text-gray-900 capitalize">{pet.sex}</span>
+                          <span className="text-surface-500">Sex:</span>
+                          <span className="ml-1 text-navy capitalize">{pet.sex}</span>
                         </div>
                       )}
                       {pet.weight && (
                         <div>
-                          <span className="text-gray-500">Weight:</span>
-                          <span className="ml-1 text-gray-900">{pet.weight} lbs</span>
+                          <span className="text-surface-500">Weight:</span>
+                          <span className="ml-1 text-navy">{pet.weight} lbs</span>
                         </div>
                       )}
                       {pet.microchip_number && (
                         <div>
-                          <span className="text-gray-500">Microchip:</span>
-                          <span className="ml-1 text-gray-900 font-mono text-xs">{pet.microchip_number}</span>
+                          <span className="text-surface-500">Microchip:</span>
+                          <span className="ml-1 text-navy font-mono text-xs">{pet.microchip_number}</span>
                         </div>
                       )}
                     </div>
@@ -145,19 +145,19 @@ export default function PetDetailModal({ petId, onClose }: Props) {
               </div>
 
               {/* Owner Info */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">Primary Owner</h3>
+              <div className="bg-surface rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-navy mb-3">Primary Owner</h3>
                 <div className="bg-white rounded-lg p-3">
-                  <p className="font-medium text-gray-900">{pet.owner_name}</p>
-                  <p className="text-sm text-gray-600">{pet.owner_email}</p>
-                  <p className="text-xs text-gray-500 mt-1">User ID: {pet.owner_id}</p>
+                  <p className="font-medium text-navy">{pet.owner_name}</p>
+                  <p className="text-sm text-surface-600">{pet.owner_email}</p>
+                  <p className="text-xs text-surface-500 mt-1">User ID: {pet.owner_id}</p>
                 </div>
               </div>
 
               {/* Shared Access */}
               {pet.owners && pet.owners.length > 1 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">
                     Shared Access ({pet.owners.length - 1})
                   </h3>
                   <div className="space-y-2">
@@ -166,19 +166,19 @@ export default function PetDetailModal({ petId, onClose }: Props) {
                       .map((owner) => (
                         <div key={owner.user_id} className="bg-white rounded-lg p-3 flex items-center justify-between">
                           <div>
-                            <p className="text-sm font-medium text-gray-900">{owner.name}</p>
-                            <p className="text-xs text-gray-600">{owner.email}</p>
+                            <p className="text-sm font-medium text-navy">{owner.name}</p>
+                            <p className="text-xs text-surface-600">{owner.email}</p>
                           </div>
                           <div className="flex items-center space-x-2">
                             <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                               owner.role === 'editor'
-                                ? 'bg-blue-100 text-blue-800'
-                                : 'bg-gray-100 text-gray-800'
+                                ? 'bg-info-light text-info'
+                                : 'bg-surface-100 text-navy'
                             }`}>
                               {owner.role}
                             </span>
                             {!owner.accepted_at && (
-                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warning-light text-warning-dark">
                                 Pending
                               </span>
                             )}
@@ -191,38 +191,38 @@ export default function PetDetailModal({ petId, onClose }: Props) {
 
               {/* Health Records Summary */}
               <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-                <div className="bg-blue-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-blue-900">{pet.vet_count}</p>
-                  <p className="text-sm text-blue-700">Vets</p>
+                <div className="bg-info-light rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-navy">{pet.vet_count}</p>
+                  <p className="text-sm text-info">Vets</p>
                 </div>
-                <div className="bg-purple-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-purple-900">{pet.condition_count}</p>
-                  <p className="text-sm text-purple-700">Conditions</p>
+                <div className="bg-surface-100 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-navy">{pet.condition_count}</p>
+                  <p className="text-sm text-surface-700">Conditions</p>
                 </div>
-                <div className="bg-red-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-red-900">{pet.allergy_count}</p>
-                  <p className="text-sm text-red-700">Allergies</p>
+                <div className="bg-danger-light rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-navy">{pet.allergy_count}</p>
+                  <p className="text-sm text-danger">Allergies</p>
                 </div>
-                <div className="bg-green-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-green-900">{pet.medication_count}</p>
-                  <p className="text-sm text-green-700">Medications</p>
+                <div className="bg-success-light rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-navy">{pet.medication_count}</p>
+                  <p className="text-sm text-success">Medications</p>
                 </div>
-                <div className="bg-amber-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-amber-900">{pet.vaccination_count}</p>
-                  <p className="text-sm text-amber-700">Vaccinations</p>
+                <div className="bg-warning-light rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-navy">{pet.vaccination_count}</p>
+                  <p className="text-sm text-warning-dark">Vaccinations</p>
                 </div>
               </div>
 
               {/* Vets */}
               {pet.vets && pet.vets.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Vets ({pet.vets.length})</h3>
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">Vets ({pet.vets.length})</h3>
                   <div className="space-y-2">
                     {pet.vets.map((vet) => (
                       <div key={vet.id} className="bg-white rounded-lg p-3">
-                        <p className="font-medium text-gray-900">{vet.name}</p>
-                        {vet.clinic_name && <p className="text-sm text-gray-600">{vet.clinic_name}</p>}
-                        <div className="mt-1 text-xs text-gray-500 space-x-3">
+                        <p className="font-medium text-navy">{vet.name}</p>
+                        {vet.clinic_name && <p className="text-sm text-surface-600">{vet.clinic_name}</p>}
+                        <div className="mt-1 text-xs text-surface-500 space-x-3">
                           {vet.phone && <span>{vet.phone}</span>}
                           {vet.email && <span>{vet.email}</span>}
                         </div>
@@ -234,18 +234,18 @@ export default function PetDetailModal({ petId, onClose }: Props) {
 
               {/* Conditions */}
               {pet.conditions && pet.conditions.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Conditions ({pet.conditions.length})</h3>
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">Conditions ({pet.conditions.length})</h3>
                   <div className="space-y-2">
                     {pet.conditions.map((condition) => (
                       <div key={condition.id} className="bg-white rounded-lg p-3">
-                        <p className="font-medium text-gray-900">{condition.name}</p>
+                        <p className="font-medium text-navy">{condition.name}</p>
                         {condition.diagnosed_date && (
-                          <p className="text-xs text-gray-500">
+                          <p className="text-xs text-surface-500">
                             Diagnosed: {new Date(condition.diagnosed_date).toLocaleDateString()}
                           </p>
                         )}
-                        {condition.notes && <p className="text-sm text-gray-600 mt-1">{condition.notes}</p>}
+                        {condition.notes && <p className="text-sm text-surface-600 mt-1">{condition.notes}</p>}
                       </div>
                     ))}
                   </div>
@@ -254,23 +254,23 @@ export default function PetDetailModal({ petId, onClose }: Props) {
 
               {/* Allergies */}
               {pet.allergies && pet.allergies.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Allergies ({pet.allergies.length})</h3>
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">Allergies ({pet.allergies.length})</h3>
                   <div className="space-y-2">
                     {pet.allergies.map((allergy) => (
                       <div key={allergy.id} className="bg-white rounded-lg p-3">
                         <div className="flex items-start justify-between">
                           <div>
-                            <p className="font-medium text-gray-900">{allergy.allergen}</p>
-                            {allergy.reaction && <p className="text-sm text-gray-600">{allergy.reaction}</p>}
+                            <p className="font-medium text-navy">{allergy.allergen}</p>
+                            {allergy.reaction && <p className="text-sm text-surface-600">{allergy.reaction}</p>}
                           </div>
                           {allergy.severity && (
                             <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                               allergy.severity === 'severe'
-                                ? 'bg-red-100 text-red-800'
+                                ? 'bg-danger-light text-danger'
                                 : allergy.severity === 'moderate'
-                                ? 'bg-yellow-100 text-yellow-800'
-                                : 'bg-green-100 text-green-800'
+                                ? 'bg-warning-light text-warning-dark'
+                                : 'bg-success-light text-success'
                             }`}>
                               {allergy.severity}
                             </span>
@@ -284,18 +284,18 @@ export default function PetDetailModal({ petId, onClose }: Props) {
 
               {/* Medications */}
               {pet.medications && pet.medications.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Medications ({pet.medications.length})</h3>
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">Medications ({pet.medications.length})</h3>
                   <div className="space-y-2">
                     {pet.medications.map((medication) => (
                       <div key={medication.id} className="bg-white rounded-lg p-3">
-                        <p className="font-medium text-gray-900">{medication.name}</p>
-                        <div className="mt-1 text-sm text-gray-600 space-x-3">
+                        <p className="font-medium text-navy">{medication.name}</p>
+                        <div className="mt-1 text-sm text-surface-600 space-x-3">
                           {medication.dosage && <span>Dosage: {medication.dosage}</span>}
                           {medication.frequency && <span>Frequency: {medication.frequency}</span>}
                         </div>
                         {medication.start_date && (
-                          <p className="text-xs text-gray-500 mt-1">
+                          <p className="text-xs text-surface-500 mt-1">
                             Started: {new Date(medication.start_date).toLocaleDateString()}
                           </p>
                         )}
@@ -307,13 +307,13 @@ export default function PetDetailModal({ petId, onClose }: Props) {
 
               {/* Vaccinations */}
               {pet.vaccinations && pet.vaccinations.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Vaccinations ({pet.vaccinations.length})</h3>
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">Vaccinations ({pet.vaccinations.length})</h3>
                   <div className="space-y-2">
                     {pet.vaccinations.map((vaccination) => (
                       <div key={vaccination.id} className="bg-white rounded-lg p-3">
-                        <p className="font-medium text-gray-900">{vaccination.name}</p>
-                        <div className="mt-1 text-xs text-gray-500 space-x-3">
+                        <p className="font-medium text-navy">{vaccination.name}</p>
+                        <div className="mt-1 text-xs text-surface-500 space-x-3">
                           {vaccination.date_administered && (
                             <span>Administered: {new Date(vaccination.date_administered).toLocaleDateString()}</span>
                           )}
@@ -330,13 +330,13 @@ export default function PetDetailModal({ petId, onClose }: Props) {
               {/* Share Info */}
               {pet.share_id && (
                 <div className="bg-primary-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Emergency Card</h3>
+                  <h3 className="text-lg font-semibold text-navy mb-3">Emergency Card</h3>
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm text-gray-700">
+                      <p className="text-sm text-surface-700">
                         Emergency card is {pet.is_emergency_card_enabled ? 'enabled' : 'disabled'}
                       </p>
-                      <p className="text-xs text-gray-500 font-mono mt-1">Share ID: {pet.share_id}</p>
+                      <p className="text-xs text-surface-500 font-mono mt-1">Share ID: {pet.share_id}</p>
                     </div>
                     {pet.is_emergency_card_enabled && (
                       <button
@@ -351,7 +351,7 @@ export default function PetDetailModal({ petId, onClose }: Props) {
               )}
 
               {/* Metadata */}
-              <div className="text-xs text-gray-500 pt-4 border-t border-gray-200">
+              <div className="text-xs text-surface-500 pt-4 border-t border-surface-200">
                 <p>Created: {new Date(pet.created_at).toLocaleString()}</p>
               </div>
             </div>

--- a/frontend/src/pages/admin/PetsList.tsx
+++ b/frontend/src/pages/admin/PetsList.tsx
@@ -104,7 +104,7 @@ export default function PetsList() {
   const SortIcon = ({ column }: { column: string }) => {
     if (sortBy !== column) {
       return (
-        <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-4 h-4 text-surface-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
         </svg>
       );
@@ -124,14 +124,14 @@ export default function PetsList() {
     <div className="max-w-7xl mx-auto">
       {/* Header */}
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Pets</h1>
-        <p className="text-gray-600 mt-1">View all pet profiles and health records</p>
+        <h1 className="text-2xl font-bold text-navy">Pets</h1>
+        <p className="text-surface-600 mt-1">View all pet profiles and health records</p>
       </div>
 
       {error && (
-        <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg flex items-center justify-between">
+        <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg flex items-center justify-between">
           <span>{error}</span>
-          <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600">
+          <button onClick={() => setError(null)} className="text-danger hover:text-danger-dark">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -176,31 +176,31 @@ export default function PetsList() {
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
           </div>
         ) : pets.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
+          <div className="text-center py-12 text-surface-500">
             <p>No pets found.</p>
           </div>
         ) : (
           <>
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-gray-50 border-b border-gray-200">
+                <thead className="bg-surface border-b border-surface-200">
                   <tr>
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('id')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>ID</span>
                         <SortIcon column="id" />
                       </button>
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                    <th className="px-4 py-3 text-left text-xs font-medium text-surface-700 uppercase tracking-wider">
                       Photo
                     </th>
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('name')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Name</span>
                         <SortIcon column="name" />
@@ -209,7 +209,7 @@ export default function PetsList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('species')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Species</span>
                         <SortIcon column="species" />
@@ -218,19 +218,19 @@ export default function PetsList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('owner_name')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Owner</span>
                         <SortIcon column="owner_name" />
                       </button>
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                    <th className="px-4 py-3 text-left text-xs font-medium text-surface-700 uppercase tracking-wider">
                       Records
                     </th>
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('created_at')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Created</span>
                         <SortIcon column="created_at" />
@@ -238,14 +238,14 @@ export default function PetsList() {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-100">
+                <tbody className="divide-y divide-surface-100">
                   {pets.map((pet) => (
                     <tr
                       key={pet.id}
                       onClick={() => setSelectedPetId(pet.id)}
-                      className="hover:bg-gray-50 cursor-pointer transition-colors"
+                      className="hover:bg-surface cursor-pointer transition-colors"
                     >
-                      <td className="px-4 py-3 text-sm font-mono text-gray-500">{pet.id}</td>
+                      <td className="px-4 py-3 text-sm font-mono text-surface-500">{pet.id}</td>
                       <td className="px-4 py-3">
                         <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center overflow-hidden">
                           {pet.photo_url ? (
@@ -262,27 +262,27 @@ export default function PetsList() {
                         </div>
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm font-medium text-gray-900">{pet.name}</span>
+                        <span className="text-sm font-medium text-navy">{pet.name}</span>
                       </td>
                       <td className="px-4 py-3">
                         <div>
-                          <span className="text-sm text-gray-900 capitalize">{pet.species}</span>
+                          <span className="text-sm text-navy capitalize">{pet.species}</span>
                           {pet.breed && (
-                            <span className="text-sm text-gray-500"> • {pet.breed}</span>
+                            <span className="text-sm text-surface-500"> • {pet.breed}</span>
                           )}
                         </div>
                       </td>
                       <td className="px-4 py-3">
                         <div>
-                          <div className="text-sm text-gray-900">{pet.owner_name}</div>
-                          <div className="text-xs text-gray-500">{pet.owner_email}</div>
+                          <div className="text-sm text-navy">{pet.owner_name}</div>
+                          <div className="text-xs text-surface-500">{pet.owner_email}</div>
                         </div>
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-gray-900">{getTotalRecords(pet)}</span>
+                        <span className="text-sm text-navy">{getTotalRecords(pet)}</span>
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-gray-600">{formatRelativeDate(pet.created_at)}</span>
+                        <span className="text-sm text-surface-600">{formatRelativeDate(pet.created_at)}</span>
                       </td>
                     </tr>
                   ))}
@@ -291,22 +291,22 @@ export default function PetsList() {
             </div>
 
             {/* Pagination */}
-            <div className="px-4 py-3 border-t border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-3">
-              <div className="text-sm text-gray-700 text-center sm:text-left">
+            <div className="px-4 py-3 border-t border-surface-200 flex flex-col sm:flex-row items-center justify-between gap-3">
+              <div className="text-sm text-surface-700 text-center sm:text-left">
                 Showing {page * limit + 1} to {Math.min((page + 1) * limit, total)} of {total} pets
               </div>
               <div className="flex space-x-2">
                 <button
                   onClick={handlePrevPage}
                   disabled={page === 0}
-                  className="px-3 py-1.5 rounded border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 py-1.5 rounded border border-surface-300 text-sm font-medium text-surface-700 hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Previous
                 </button>
                 <button
                   onClick={handleNextPage}
                   disabled={(page + 1) * limit >= total}
-                  className="px-3 py-1.5 rounded border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 py-1.5 rounded border border-surface-300 text-sm font-medium text-surface-700 hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Next
                 </button>

--- a/frontend/src/pages/admin/SubscriptionSettings.tsx
+++ b/frontend/src/pages/admin/SubscriptionSettings.tsx
@@ -132,20 +132,20 @@ export default function SubscriptionSettings() {
     <div className="max-w-4xl mx-auto">
       {/* Page header */}
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">Subscription Settings</h1>
-        <p className="text-gray-600 mt-1">Manage pricing, trial periods, and Stripe configuration</p>
+        <h1 className="text-2xl font-bold text-navy">Subscription Settings</h1>
+        <p className="text-surface-600 mt-1">Manage pricing, trial periods, and Stripe configuration</p>
       </div>
 
       {/* Success message */}
       {successMessage && (
-        <div className="mb-6 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg flex items-center justify-between">
+        <div className="mb-6 bg-success-light border border-success-light text-success px-4 py-3 rounded-lg flex items-center justify-between">
           <span className="flex items-center">
             <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
             {successMessage}
           </span>
-          <button onClick={() => setSuccessMessage(null)} className="text-green-500 hover:text-green-700">
+          <button onClick={() => setSuccessMessage(null)} className="text-success hover:text-success">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -155,9 +155,9 @@ export default function SubscriptionSettings() {
 
       {/* Error message */}
       {error && (
-        <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg flex items-center justify-between">
+        <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg flex items-center justify-between">
           <span>{error}</span>
-          <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600">
+          <button onClick={() => setError(null)} className="text-danger hover:text-danger-dark">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -167,14 +167,14 @@ export default function SubscriptionSettings() {
 
       {/* Pricing Section */}
       <div className="bg-white rounded-lg shadow-sm mb-6">
-        <div className="px-6 py-4 border-b border-gray-100">
-          <h2 className="text-lg font-medium text-gray-900">Pricing</h2>
-          <p className="text-sm text-gray-500 mt-1">Set subscription prices for monthly and annual plans</p>
+        <div className="px-6 py-4 border-b border-surface-100">
+          <h2 className="text-lg font-medium text-navy">Pricing</h2>
+          <p className="text-sm text-surface-500 mt-1">Set subscription prices for monthly and annual plans</p>
         </div>
         <form onSubmit={handleSavePricing} className="p-6 space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label htmlFor="monthly_price" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="monthly_price" className="block text-sm font-medium text-surface-700 mb-1">
                 Monthly Price ($)
               </label>
               <input
@@ -189,10 +189,10 @@ export default function SubscriptionSettings() {
                 className="input w-full"
                 placeholder="9.99"
               />
-              <p className="text-xs text-gray-500 mt-1">{pricing.monthly_price_cents} cents</p>
+              <p className="text-xs text-surface-500 mt-1">{pricing.monthly_price_cents} cents</p>
             </div>
             <div>
-              <label htmlFor="annual_price" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="annual_price" className="block text-sm font-medium text-surface-700 mb-1">
                 Annual Price ($)
               </label>
               <input
@@ -207,10 +207,10 @@ export default function SubscriptionSettings() {
                 className="input w-full"
                 placeholder="99.99"
               />
-              <p className="text-xs text-gray-500 mt-1">{pricing.annual_price_cents} cents</p>
+              <p className="text-xs text-surface-500 mt-1">{pricing.annual_price_cents} cents</p>
             </div>
             <div>
-              <label htmlFor="currency" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="currency" className="block text-sm font-medium text-surface-700 mb-1">
                 Currency
               </label>
               <select
@@ -249,14 +249,14 @@ export default function SubscriptionSettings() {
 
       {/* Trial Section */}
       <div className="bg-white rounded-lg shadow-sm mb-6">
-        <div className="px-6 py-4 border-b border-gray-100">
-          <h2 className="text-lg font-medium text-gray-900">Trial Period</h2>
-          <p className="text-sm text-gray-500 mt-1">Configure free trial settings for new users</p>
+        <div className="px-6 py-4 border-b border-surface-100">
+          <h2 className="text-lg font-medium text-navy">Trial Period</h2>
+          <p className="text-sm text-surface-500 mt-1">Configure free trial settings for new users</p>
         </div>
         <form onSubmit={handleSaveTrial} className="p-6 space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label htmlFor="trial_days" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="trial_days" className="block text-sm font-medium text-surface-700 mb-1">
                 Trial Days
               </label>
               <input
@@ -269,7 +269,7 @@ export default function SubscriptionSettings() {
                 className="input w-full"
                 placeholder="14"
               />
-              <p className="text-xs text-gray-500 mt-1">Number of days for free trial (0 to disable)</p>
+              <p className="text-xs text-surface-500 mt-1">Number of days for free trial (0 to disable)</p>
             </div>
             <div className="flex items-center pt-6">
               <label className="flex items-center cursor-pointer">
@@ -277,11 +277,11 @@ export default function SubscriptionSettings() {
                   type="checkbox"
                   checked={trial.require_card}
                   onChange={(e) => setTrial({ ...trial, require_card: e.target.checked })}
-                  className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="w-4 h-4 text-primary-600 border-surface-300 rounded focus:ring-primary-500"
                 />
                 <span className="ml-3">
-                  <span className="text-sm font-medium text-gray-700">Require card for trial</span>
-                  <p className="text-xs text-gray-500">Users must enter payment info to start trial</p>
+                  <span className="text-sm font-medium text-surface-700">Require card for trial</span>
+                  <p className="text-xs text-surface-500">Users must enter payment info to start trial</p>
                 </span>
               </label>
             </div>
@@ -308,14 +308,14 @@ export default function SubscriptionSettings() {
 
       {/* Stripe Section */}
       <div className="bg-white rounded-lg shadow-sm">
-        <div className="px-6 py-4 border-b border-gray-100">
-          <h2 className="text-lg font-medium text-gray-900">Stripe Configuration</h2>
-          <p className="text-sm text-gray-500 mt-1">Connect your Stripe price IDs and webhook secret</p>
+        <div className="px-6 py-4 border-b border-surface-100">
+          <h2 className="text-lg font-medium text-navy">Stripe Configuration</h2>
+          <p className="text-sm text-surface-500 mt-1">Connect your Stripe price IDs and webhook secret</p>
         </div>
         <form onSubmit={handleSaveStripe} className="p-6 space-y-4">
           <div className="grid grid-cols-1 gap-4">
             <div>
-              <label htmlFor="price_id_monthly" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="price_id_monthly" className="block text-sm font-medium text-surface-700 mb-1">
                 Monthly Price ID
               </label>
               <input
@@ -326,10 +326,10 @@ export default function SubscriptionSettings() {
                 className="input w-full font-mono text-sm"
                 placeholder="price_1A2B3C4D5E6F7G8H9I0J"
               />
-              <p className="text-xs text-gray-500 mt-1">Find this in your Stripe dashboard under Products</p>
+              <p className="text-xs text-surface-500 mt-1">Find this in your Stripe dashboard under Products</p>
             </div>
             <div>
-              <label htmlFor="price_id_annual" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="price_id_annual" className="block text-sm font-medium text-surface-700 mb-1">
                 Annual Price ID
               </label>
               <input
@@ -342,7 +342,7 @@ export default function SubscriptionSettings() {
               />
             </div>
             <div>
-              <label htmlFor="webhook_secret" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="webhook_secret" className="block text-sm font-medium text-surface-700 mb-1">
                 Webhook Secret
               </label>
               <input
@@ -353,7 +353,7 @@ export default function SubscriptionSettings() {
                 className="input w-full font-mono text-sm"
                 placeholder="whsec_..."
               />
-              <p className="text-xs text-gray-500 mt-1">Find this in Stripe Webhooks settings</p>
+              <p className="text-xs text-surface-500 mt-1">Find this in Stripe Webhooks settings</p>
             </div>
           </div>
           <div className="pt-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">

--- a/frontend/src/pages/admin/UserDetailModal.tsx
+++ b/frontend/src/pages/admin/UserDetailModal.tsx
@@ -58,14 +58,14 @@ export default function UserDetailModal({ userId, onClose }: Props) {
           {/* Header */}
           <div className="flex justify-between items-start mb-6">
             <div>
-              <h2 className="text-2xl font-bold text-gray-900">User Details</h2>
+              <h2 className="text-2xl font-bold text-navy">User Details</h2>
               {user && (
-                <p className="text-sm text-gray-500 mt-1">ID: {user.id}</p>
+                <p className="text-sm text-surface-500 mt-1">ID: {user.id}</p>
               )}
             </div>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-surface-400 hover:text-surface-600 transition-colors"
             >
               <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -74,7 +74,7 @@ export default function UserDetailModal({ userId, onClose }: Props) {
           </div>
 
           {error && (
-            <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -86,30 +86,30 @@ export default function UserDetailModal({ userId, onClose }: Props) {
           ) : user ? (
             <div className="space-y-6">
               {/* User Profile */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">Profile</h3>
+              <div className="bg-surface rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-navy mb-3">Profile</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Name</label>
-                    <p className="text-gray-900">{user.name}</p>
+                    <label className="text-sm font-medium text-surface-500">Name</label>
+                    <p className="text-navy">{user.name}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Email</label>
-                    <p className="text-gray-900">{user.email}</p>
+                    <label className="text-sm font-medium text-surface-500">Email</label>
+                    <p className="text-navy">{user.email}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Phone</label>
-                    <p className="text-gray-900">{user.phone || '—'}</p>
+                    <label className="text-sm font-medium text-surface-500">Phone</label>
+                    <p className="text-navy">{user.phone || '—'}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Admin Status</label>
+                    <label className="text-sm font-medium text-surface-500">Admin Status</label>
                     <p>
                       {user.is_admin ? (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-light text-success">
                           Admin
                         </span>
                       ) : (
-                        <span className="text-gray-600">Regular User</span>
+                        <span className="text-surface-600">Regular User</span>
                       )}
                     </p>
                   </div>
@@ -117,42 +117,42 @@ export default function UserDetailModal({ userId, onClose }: Props) {
               </div>
 
               {/* Subscription Info */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">Subscription</h3>
+              <div className="bg-surface rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-navy mb-3">Subscription</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Plan</label>
-                    <p className="text-gray-900 capitalize">{user.subscription_tier}</p>
+                    <label className="text-sm font-medium text-surface-500">Plan</label>
+                    <p className="text-navy capitalize">{user.subscription_tier}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Status</label>
+                    <label className="text-sm font-medium text-surface-500">Status</label>
                     <p>
                       {user.subscription_tier === 'premium' ? (
                         <>
                           {user.subscription_status === 'active' && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Active</span>
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-light text-success">Active</span>
                           )}
                           {user.subscription_status === 'trialing' && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">Trial</span>
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-info-light text-info">Trial</span>
                           )}
                           {user.subscription_status === 'past_due' && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">Past Due</span>
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warning-light text-warning-dark">Past Due</span>
                           )}
                           {user.subscription_status === 'canceled' && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">Canceled</span>
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-danger-light text-danger">Canceled</span>
                           )}
                         </>
                       ) : (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Free</span>
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-100 text-surface-600">Free</span>
                       )}
                     </p>
                   </div>
                   {user.subscription_current_period_end && (
                     <div className="md:col-span-2">
-                      <label className="text-sm font-medium text-gray-500">
+                      <label className="text-sm font-medium text-surface-500">
                         {user.subscription_status === 'canceled' ? 'Access Until' : 'Current Period Ends'}
                       </label>
-                      <p className="text-gray-900">
+                      <p className="text-navy">
                         {new Date(user.subscription_current_period_end).toLocaleDateString('en-US', {
                           year: 'numeric',
                           month: 'long',
@@ -165,32 +165,32 @@ export default function UserDetailModal({ userId, onClose }: Props) {
               </div>
 
               {/* Account Info */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">Account Info</h3>
+              <div className="bg-surface rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-navy mb-3">Account Info</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Created</label>
-                    <p className="text-gray-900">{new Date(user.created_at).toLocaleString()}</p>
+                    <label className="text-sm font-medium text-surface-500">Created</label>
+                    <p className="text-navy">{new Date(user.created_at).toLocaleString()}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Last Updated</label>
-                    <p className="text-gray-900">{new Date(user.updated_at).toLocaleString()}</p>
+                    <label className="text-sm font-medium text-surface-500">Last Updated</label>
+                    <p className="text-navy">{new Date(user.updated_at).toLocaleString()}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Owned Pets</label>
-                    <p className="text-gray-900 font-semibold">{user.owned_pet_count}</p>
+                    <label className="text-sm font-medium text-surface-500">Owned Pets</label>
+                    <p className="text-navy font-semibold">{user.owned_pet_count}</p>
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-gray-500">Shared Pets</label>
-                    <p className="text-gray-900 font-semibold">{user.shared_pet_count}</p>
+                    <label className="text-sm font-medium text-surface-500">Shared Pets</label>
+                    <p className="text-navy font-semibold">{user.shared_pet_count}</p>
                   </div>
                 </div>
               </div>
 
               {/* Pets List */}
               {user.pets && user.pets.length > 0 && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                <div className="bg-surface rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-navy mb-3">
                     Pets ({user.pets.length})
                   </h3>
                   <div className="space-y-3">
@@ -213,14 +213,14 @@ export default function UserDetailModal({ userId, onClose }: Props) {
                           )}
                         </div>
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-semibold text-gray-900">{pet.name}</p>
-                          <p className="text-sm text-gray-500 capitalize">{pet.species}</p>
+                          <p className="text-sm font-semibold text-navy">{pet.name}</p>
+                          <p className="text-sm text-surface-500 capitalize">{pet.species}</p>
                         </div>
                         <div>
                           <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                             pet.role === 'owner'
-                              ? 'bg-blue-100 text-blue-800'
-                              : 'bg-gray-100 text-gray-800'
+                              ? 'bg-info-light text-info'
+                              : 'bg-surface-100 text-navy'
                           }`}>
                             {pet.role}
                           </span>
@@ -232,7 +232,7 @@ export default function UserDetailModal({ userId, onClose }: Props) {
               )}
 
               {user.pets && user.pets.length === 0 && (
-                <div className="text-center py-8 text-gray-500">
+                <div className="text-center py-8 text-surface-500">
                   <p>This user has no pets.</p>
                 </div>
               )}

--- a/frontend/src/pages/admin/UsersList.tsx
+++ b/frontend/src/pages/admin/UsersList.tsx
@@ -96,22 +96,22 @@ export default function UsersList() {
     if (tier === 'premium') {
       switch (status) {
         case 'active':
-          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Premium</span>;
+          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-light text-success">Premium</span>;
         case 'trialing':
-          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">Trial</span>;
+          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-info-light text-info">Trial</span>;
         case 'past_due':
-          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">Past Due</span>;
+          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warning-light text-warning-dark">Past Due</span>;
         case 'canceled':
-          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">Canceled</span>;
+          return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-danger-light text-danger">Canceled</span>;
       }
     }
-    return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Free</span>;
+    return <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-100 text-surface-600">Free</span>;
   };
 
   const SortIcon = ({ column }: { column: string }) => {
     if (sortBy !== column) {
       return (
-        <svg className="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="w-4 h-4 text-surface-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
         </svg>
       );
@@ -131,14 +131,14 @@ export default function UsersList() {
     <div className="max-w-7xl mx-auto">
       {/* Header */}
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
-        <p className="text-gray-600 mt-1">Manage user accounts and access</p>
+        <h1 className="text-2xl font-bold text-navy">Users</h1>
+        <p className="text-surface-600 mt-1">Manage user accounts and access</p>
       </div>
 
       {error && (
-        <div className="mb-6 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg flex items-center justify-between">
+        <div className="mb-6 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg flex items-center justify-between">
           <span>{error}</span>
-          <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600">
+          <button onClick={() => setError(null)} className="text-danger hover:text-danger-dark">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -182,19 +182,19 @@ export default function UsersList() {
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
           </div>
         ) : users.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
+          <div className="text-center py-12 text-surface-500">
             <p>No users found.</p>
           </div>
         ) : (
           <>
             <div className="overflow-x-auto">
               <table className="w-full">
-                <thead className="bg-gray-50 border-b border-gray-200">
+                <thead className="bg-surface border-b border-surface-200">
                   <tr>
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('id')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>ID</span>
                         <SortIcon column="id" />
@@ -203,7 +203,7 @@ export default function UsersList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('name')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Name</span>
                         <SortIcon column="name" />
@@ -212,19 +212,19 @@ export default function UsersList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('email')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Email</span>
                         <SortIcon column="email" />
                       </button>
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+                    <th className="px-4 py-3 text-left text-xs font-medium text-surface-700 uppercase tracking-wider">
                       Phone
                     </th>
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('is_admin')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Admin</span>
                         <SortIcon column="is_admin" />
@@ -233,7 +233,7 @@ export default function UsersList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('subscription_status')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Subscription</span>
                         <SortIcon column="subscription_status" />
@@ -242,7 +242,7 @@ export default function UsersList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('owned_pet_count')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Pets</span>
                         <SortIcon column="owned_pet_count" />
@@ -251,7 +251,7 @@ export default function UsersList() {
                     <th className="px-4 py-3 text-left">
                       <button
                         onClick={() => handleSort('created_at')}
-                        className="flex items-center space-x-1 text-xs font-medium text-gray-700 uppercase tracking-wider hover:text-primary-600"
+                        className="flex items-center space-x-1 text-xs font-medium text-surface-700 uppercase tracking-wider hover:text-primary-600"
                       >
                         <span>Created</span>
                         <SortIcon column="created_at" />
@@ -259,26 +259,26 @@ export default function UsersList() {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-100">
+                <tbody className="divide-y divide-surface-100">
                   {users.map((user) => (
                     <tr
                       key={user.id}
                       onClick={() => setSelectedUserId(user.id)}
-                      className="hover:bg-gray-50 cursor-pointer transition-colors"
+                      className="hover:bg-surface cursor-pointer transition-colors"
                     >
-                      <td className="px-4 py-3 text-sm font-mono text-gray-500">{user.id}</td>
+                      <td className="px-4 py-3 text-sm font-mono text-surface-500">{user.id}</td>
                       <td className="px-4 py-3">
-                        <span className="text-sm font-medium text-gray-900">{user.name}</span>
+                        <span className="text-sm font-medium text-navy">{user.name}</span>
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-gray-600">{user.email}</span>
+                        <span className="text-sm text-surface-600">{user.email}</span>
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-gray-600">{user.phone || '—'}</span>
+                        <span className="text-sm text-surface-600">{user.phone || '—'}</span>
                       </td>
                       <td className="px-4 py-3">
                         {user.is_admin && (
-                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-light text-success">
                             Admin
                           </span>
                         )}
@@ -287,12 +287,12 @@ export default function UsersList() {
                         {getSubscriptionBadge(user.subscription_status, user.subscription_tier)}
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-gray-900">
+                        <span className="text-sm text-navy">
                           {Number(user.owned_pet_count) + Number(user.shared_pet_count)}
                         </span>
                       </td>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-gray-600">{formatRelativeDate(user.created_at)}</span>
+                        <span className="text-sm text-surface-600">{formatRelativeDate(user.created_at)}</span>
                       </td>
                     </tr>
                   ))}
@@ -301,22 +301,22 @@ export default function UsersList() {
             </div>
 
             {/* Pagination */}
-            <div className="px-4 py-3 border-t border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-3">
-              <div className="text-sm text-gray-700 text-center sm:text-left">
+            <div className="px-4 py-3 border-t border-surface-200 flex flex-col sm:flex-row items-center justify-between gap-3">
+              <div className="text-sm text-surface-700 text-center sm:text-left">
                 Showing {page * limit + 1} to {Math.min((page + 1) * limit, total)} of {total} users
               </div>
               <div className="flex space-x-2">
                 <button
                   onClick={handlePrevPage}
                   disabled={page === 0}
-                  className="px-3 py-1.5 rounded border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 py-1.5 rounded border border-surface-300 text-sm font-medium text-surface-700 hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Previous
                 </button>
                 <button
                   onClick={handleNextPage}
                   disabled={(page + 1) * limit >= total}
-                  className="px-3 py-1.5 rounded border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 py-1.5 rounded border border-surface-300 text-sm font-medium text-surface-700 hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Next
                 </button>

--- a/frontend/src/pages/admin/blocks/BlockEditorModal.tsx
+++ b/frontend/src/pages/admin/blocks/BlockEditorModal.tsx
@@ -58,9 +58,9 @@ export default function BlockEditorModal({ block, onSave, onClose }: BlockEditor
         return <EmptyStateEditor content={content as any} onChange={handleContentChange as any} />;
       default:
         return (
-          <div className="p-4 bg-gray-50 rounded-lg">
-            <p className="text-gray-500">No editor available for block type: {block.block_type}</p>
-            <pre className="mt-4 text-xs text-gray-600 overflow-auto">
+          <div className="p-4 bg-surface rounded-lg">
+            <p className="text-surface-500">No editor available for block type: {block.block_type}</p>
+            <pre className="mt-4 text-xs text-surface-600 overflow-auto">
               {JSON.stringify(content, null, 2)}
             </pre>
           </div>
@@ -72,13 +72,13 @@ export default function BlockEditorModal({ block, onSave, onClose }: BlockEditor
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
       <div className="bg-white rounded-xl max-w-3xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
-          <h2 className="text-xl font-bold text-gray-900">
+        <div className="px-6 py-4 border-b border-surface-100 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-navy">
             Edit {BLOCK_TYPE_LABELS[block.block_type] || block.block_type}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
+            className="text-surface-400 hover:text-surface-600"
           >
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -89,7 +89,7 @@ export default function BlockEditorModal({ block, onSave, onClose }: BlockEditor
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6">
           {error && (
-            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg">
+            <div className="mb-4 bg-danger-light border border-danger-light text-danger px-4 py-3 rounded-lg">
               {error}
             </div>
           )}
@@ -97,7 +97,7 @@ export default function BlockEditorModal({ block, onSave, onClose }: BlockEditor
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-100 flex justify-end space-x-3">
+        <div className="px-6 py-4 border-t border-surface-100 flex justify-end space-x-3">
           <button
             type="button"
             onClick={onClose}

--- a/frontend/src/pages/admin/blocks/CTAEditor.tsx
+++ b/frontend/src/pages/admin/blocks/CTAEditor.tsx
@@ -54,8 +54,8 @@ export default function CTAEditor({ content, onChange }: CTAEditorProps) {
       </div>
 
       {/* Button */}
-      <div className="p-4 bg-gray-50 rounded-lg">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">Call to Action Button</h3>
+      <div className="p-4 bg-surface rounded-lg">
+        <h3 className="text-sm font-medium text-surface-700 mb-3">Call to Action Button</h3>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="label">Button Text</label>

--- a/frontend/src/pages/admin/blocks/FeaturesEditor.tsx
+++ b/frontend/src/pages/admin/blocks/FeaturesEditor.tsx
@@ -178,21 +178,21 @@ function SortableFeature({
     <div
       ref={setNodeRef}
       style={style}
-      className={`border border-gray-200 rounded-lg overflow-hidden ${isDragging ? 'shadow-lg' : ''}`}
+      className={`border border-surface-200 rounded-lg overflow-hidden ${isDragging ? 'shadow-lg' : ''}`}
     >
       {/* Feature header - always visible */}
-      <div className="px-4 py-3 bg-gray-50 flex items-center justify-between">
+      <div className="px-4 py-3 bg-surface flex items-center justify-between">
         <div className="flex items-center space-x-3">
           {/* Drag handle */}
           <button
             type="button"
-            className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 touch-none"
+            className="cursor-grab active:cursor-grabbing text-surface-400 hover:text-surface-600 touch-none"
             {...attributes}
             {...listeners}
           >
             <DragHandleIcon />
           </button>
-          <span className="text-gray-400 font-mono text-sm">
+          <span className="text-surface-400 font-mono text-sm">
             {String(index + 1).padStart(2, '0')}
           </span>
           {/* Highlighted icon matching the selected style */}
@@ -200,7 +200,7 @@ function SortableFeature({
             <IconPreview icon={feature.icon} className="w-6 h-6" />
           </div>
           <span
-            className="font-medium text-gray-900 cursor-pointer hover:text-primary-600"
+            className="font-medium text-navy cursor-pointer hover:text-primary-600"
             onClick={onToggleEdit}
           >
             {feature.title || 'Untitled Feature'}
@@ -209,10 +209,10 @@ function SortableFeature({
         <button
           type="button"
           onClick={onToggleEdit}
-          className="p-1 hover:bg-gray-200 rounded"
+          className="p-1 hover:bg-surface-200 rounded"
         >
           <svg
-            className={`w-5 h-5 text-gray-400 transition-transform ${isEditing ? 'rotate-180' : ''}`}
+            className={`w-5 h-5 text-surface-400 transition-transform ${isEditing ? 'rotate-180' : ''}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -224,12 +224,12 @@ function SortableFeature({
 
       {/* Feature editor - expandable */}
       {isEditing && (
-        <div className="p-4 space-y-4 border-t border-gray-200">
+        <div className="p-4 space-y-4 border-t border-surface-200">
           <div>
             <label className="label">Icon</label>
             <div
               ref={scrollContainerRef}
-              className="flex gap-2 p-3 bg-gray-50 rounded-lg overflow-x-auto"
+              className="flex gap-2 p-3 bg-surface rounded-lg overflow-x-auto"
             >
               {ICON_KEYS.map((key) => {
                 const isSelected = getNormalizedIconKey(feature.icon) === key;
@@ -242,7 +242,7 @@ function SortableFeature({
                     className={`p-3 rounded-lg flex-shrink-0 transition-all ${
                       isSelected
                         ? 'bg-primary-500 ring-2 ring-primary-600 ring-offset-2 text-white shadow-md'
-                        : 'bg-white hover:bg-gray-100 text-gray-500 hover:text-gray-700 border border-gray-200'
+                        : 'bg-white hover:bg-surface-100 text-surface-500 hover:text-surface-700 border border-surface-200'
                     }`}
                   >
                     <IconPreview icon={key} className="w-7 h-7" />
@@ -363,7 +363,7 @@ export default function FeaturesEditor({ content, onChange }: FeaturesEditorProp
       {/* Features list */}
       <div>
         <label className="label mb-3">Features ({features.length})</label>
-        <p className="text-sm text-gray-500 mb-3">Drag features to reorder them</p>
+        <p className="text-sm text-surface-500 mb-3">Drag features to reorder them</p>
 
         <DndContext
           sensors={sensors}
@@ -388,7 +388,7 @@ export default function FeaturesEditor({ content, onChange }: FeaturesEditorProp
         </DndContext>
 
         {features.length === 0 && (
-          <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-lg">
+          <div className="text-center py-8 text-surface-500 bg-surface rounded-lg">
             No features defined yet.
           </div>
         )}

--- a/frontend/src/pages/admin/blocks/FooterEditor.tsx
+++ b/frontend/src/pages/admin/blocks/FooterEditor.tsx
@@ -78,7 +78,7 @@ export default function FooterEditor({ content, onChange }: FooterEditorProps) {
           {links.map((link, index) => (
             <div
               key={index}
-              className="flex items-center space-x-2 p-3 bg-gray-50 rounded-lg"
+              className="flex items-center space-x-2 p-3 bg-surface rounded-lg"
             >
               {/* Reorder buttons */}
               <div className="flex flex-col">
@@ -86,7 +86,7 @@ export default function FooterEditor({ content, onChange }: FooterEditorProps) {
                   type="button"
                   onClick={() => handleMoveLink(index, 'up')}
                   disabled={index === 0}
-                  className="text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="text-surface-400 hover:text-surface-600 disabled:opacity-30 disabled:cursor-not-allowed"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
@@ -96,7 +96,7 @@ export default function FooterEditor({ content, onChange }: FooterEditorProps) {
                   type="button"
                   onClick={() => handleMoveLink(index, 'down')}
                   disabled={index === links.length - 1}
-                  className="text-gray-400 hover:text-gray-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="text-surface-400 hover:text-surface-600 disabled:opacity-30 disabled:cursor-not-allowed"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -126,7 +126,7 @@ export default function FooterEditor({ content, onChange }: FooterEditorProps) {
               <button
                 type="button"
                 onClick={() => handleRemoveLink(index)}
-                className="text-red-400 hover:text-red-600 p-1"
+                className="text-danger hover:text-danger-dark p-1"
               >
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -136,15 +136,15 @@ export default function FooterEditor({ content, onChange }: FooterEditorProps) {
           ))}
 
           {links.length === 0 && (
-            <div className="text-center py-4 text-gray-500 bg-gray-50 rounded-lg text-sm">
+            <div className="text-center py-4 text-surface-500 bg-surface rounded-lg text-sm">
               No footer links yet. Add one below.
             </div>
           )}
         </div>
 
         {/* Add new link */}
-        <div className="p-4 border border-dashed border-gray-300 rounded-lg">
-          <h4 className="text-sm font-medium text-gray-700 mb-3">Add New Link</h4>
+        <div className="p-4 border border-dashed border-surface-300 rounded-lg">
+          <h4 className="text-sm font-medium text-surface-700 mb-3">Add New Link</h4>
           <div className="flex items-end space-x-2">
             <div className="flex-1">
               <label className="label text-xs">Label</label>

--- a/frontend/src/pages/admin/blocks/HeroEditor.tsx
+++ b/frontend/src/pages/admin/blocks/HeroEditor.tsx
@@ -62,8 +62,8 @@ export default function HeroEditor({ content, onChange }: HeroEditorProps) {
       </div>
 
       {/* Primary CTA */}
-      <div className="p-4 bg-gray-50 rounded-lg">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">Primary Button</h3>
+      <div className="p-4 bg-surface rounded-lg">
+        <h3 className="text-sm font-medium text-surface-700 mb-3">Primary Button</h3>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="label">Button Text</label>
@@ -89,8 +89,8 @@ export default function HeroEditor({ content, onChange }: HeroEditorProps) {
       </div>
 
       {/* Secondary CTA */}
-      <div className="p-4 bg-gray-50 rounded-lg">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">Secondary Button</h3>
+      <div className="p-4 bg-surface rounded-lg">
+        <h3 className="text-sm font-medium text-surface-700 mb-3">Secondary Button</h3>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="label">Button Text</label>

--- a/frontend/src/pages/admin/blocks/HowItWorksEditor.tsx
+++ b/frontend/src/pages/admin/blocks/HowItWorksEditor.tsx
@@ -72,23 +72,23 @@ export default function HowItWorksEditor({ content, onChange }: HowItWorksEditor
           {steps.map((step, index) => (
             <div
               key={index}
-              className="border border-gray-200 rounded-lg overflow-hidden"
+              className="border border-surface-200 rounded-lg overflow-hidden"
             >
               {/* Step header - always visible */}
               <div
-                className="px-4 py-3 bg-gray-50 flex items-center justify-between cursor-pointer hover:bg-gray-100"
+                className="px-4 py-3 bg-surface flex items-center justify-between cursor-pointer hover:bg-surface-100"
                 onClick={() => setEditingIndex(editingIndex === index ? null : index)}
               >
                 <div className="flex items-center space-x-3">
                   <span className="w-7 h-7 rounded-full bg-primary-600 text-white flex items-center justify-center text-sm font-bold">
                     {index + 1}
                   </span>
-                  <span className="font-medium text-gray-900">
+                  <span className="font-medium text-navy">
                     {step.title || 'Untitled Step'}
                   </span>
                 </div>
                 <svg
-                  className={`w-5 h-5 text-gray-400 transition-transform ${
+                  className={`w-5 h-5 text-surface-400 transition-transform ${
                     editingIndex === index ? 'rotate-180' : ''
                   }`}
                   fill="none"
@@ -101,7 +101,7 @@ export default function HowItWorksEditor({ content, onChange }: HowItWorksEditor
 
               {/* Step editor - expandable */}
               {editingIndex === index && (
-                <div className="p-4 space-y-4 border-t border-gray-200">
+                <div className="p-4 space-y-4 border-t border-surface-200">
                   <div>
                     <label className="label">Step Title</label>
                     <input
@@ -124,7 +124,7 @@ export default function HowItWorksEditor({ content, onChange }: HowItWorksEditor
                     />
                   </div>
 
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-surface-500">
                     Step number is auto-assigned based on order.
                   </p>
                 </div>
@@ -134,7 +134,7 @@ export default function HowItWorksEditor({ content, onChange }: HowItWorksEditor
         </div>
 
         {steps.length === 0 && (
-          <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-lg">
+          <div className="text-center py-8 text-surface-500 bg-surface rounded-lg">
             No steps defined yet.
           </div>
         )}

--- a/frontend/src/pages/pet-profile/EmergencyCardPreview.tsx
+++ b/frontend/src/pages/pet-profile/EmergencyCardPreview.tsx
@@ -95,7 +95,7 @@ export default function EmergencyCardPreview({
   return (
     <div>
       {/* Mobile device frame */}
-      <div className="max-w-[375px] rounded-3xl border border-surface-300 shadow-[0_4px_24px_rgba(0,0,0,0.10)] overflow-hidden bg-surface-100">
+      <div className="max-w-[375px] rounded-2xl border border-surface-200 shadow-token-sm overflow-hidden bg-white">
         <EmergencyCard card={card} />
       </div>
 

--- a/frontend/src/pages/pet-profile/EmergencyCardPreview.tsx
+++ b/frontend/src/pages/pet-profile/EmergencyCardPreview.tsx
@@ -94,11 +94,18 @@ export default function EmergencyCardPreview({
 
   return (
     <div>
-      {/* Mobile device frame */}
-      <div className="max-w-[375px] rounded-2xl border border-surface-200 shadow-token-sm overflow-hidden bg-white">
+      {/* Phone-frame preview — constrained window, scrollable */}
+      <div
+        className="max-w-[375px] rounded-2xl border border-surface-200 shadow-token-sm bg-white"
+        style={{
+          maxHeight: '480px',
+          overflowY: 'auto',
+          scrollbarWidth: 'thin',
+          scrollbarColor: 'var(--color-surface-300) transparent',
+        }}
+      >
         <EmergencyCard card={card} />
       </div>
-
     </div>
   );
 }

--- a/frontend/src/pages/pet-profile/EmergencyCardPreview.tsx
+++ b/frontend/src/pages/pet-profile/EmergencyCardPreview.tsx
@@ -95,14 +95,7 @@ export default function EmergencyCardPreview({
   return (
     <div>
       {/* Mobile device frame */}
-      <div style={{
-        maxWidth: '375px',
-        borderRadius: '24px',
-        border: '1px solid var(--color-surface-300)',
-        boxShadow: '0 4px 24px rgba(0,0,0,0.10)',
-        overflow: 'hidden',
-        background: 'var(--color-surface-100)',
-      }}>
+      <div className="max-w-[375px] rounded-3xl border border-surface-300 shadow-[0_4px_24px_rgba(0,0,0,0.10)] overflow-hidden bg-surface-100">
         <EmergencyCard card={card} />
       </div>
 

--- a/frontend/src/pages/pet-profile/sections/ActivitySection.tsx
+++ b/frontend/src/pages/pet-profile/sections/ActivitySection.tsx
@@ -20,7 +20,7 @@ export default function ActivitySection() {
         ) : (
           <div className="space-y-4">
             <UpgradeBanner type="feature" feature="timeline" />
-            <p className="text-gray-500 text-center py-4">
+            <p className="text-surface-500 text-center py-4">
               Upgrade to premium to view a visual timeline of your pet's medical history.
             </p>
           </div>

--- a/frontend/src/pages/pet-profile/sections/DocumentsSection.tsx
+++ b/frontend/src/pages/pet-profile/sections/DocumentsSection.tsx
@@ -19,7 +19,7 @@ export default function DocumentsSection() {
         ) : (
           <div className="space-y-4">
             <UpgradeBanner type="feature" feature="upload" />
-            <p className="text-gray-500 text-center py-4">
+            <p className="text-surface-500 text-center py-4">
               Upgrade to premium to import medical records from PDFs and photos.
             </p>
           </div>

--- a/frontend/src/pages/pet-profile/sections/HealthRecordsSection.tsx
+++ b/frontend/src/pages/pet-profile/sections/HealthRecordsSection.tsx
@@ -155,7 +155,7 @@ export default function HealthRecordsSection() {
             </svg>
             Medications
             {activeMeds.length > 0 && (
-              <span className="badge badge-info">{activeMeds.length} active</span>
+              <span className="badge badge-navy">{activeMeds.length} active</span>
             )}
           </div>
           <svg className="health-accordion-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -190,7 +190,7 @@ export default function HealthRecordsSection() {
             {expiringVacs.length > 0 ? (
               <span className="badge badge-danger">{expiringVacs.length} expiring</span>
             ) : vaccinations.length > 0 ? (
-              <span className="badge badge-success">{vaccinations.length} recorded</span>
+              <span className="badge badge-navy">{vaccinations.length} recorded</span>
             ) : null}
           </div>
           <svg className="health-accordion-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/frontend/src/pages/pet-profile/sections/OverviewSection.tsx
+++ b/frontend/src/pages/pet-profile/sections/OverviewSection.tsx
@@ -31,29 +31,29 @@ export default function OverviewSection() {
           {/* Stat blocks */}
           <div className="pet-profile-stats">
             <div className="pet-profile-stat" onClick={() => navigate('health#conditions')}>
-              <div className="pet-profile-stat-value text-warning">{conditions.length}</div>
+              <div className="pet-profile-stat-value text-navy">{conditions.length}</div>
               <div className="pet-profile-stat-label">Conditions</div>
             </div>
             <div className="pet-profile-stat" onClick={() => navigate('health#allergies')}>
-              <div className="pet-profile-stat-value text-danger">{allergies.length}</div>
+              <div className="pet-profile-stat-value text-navy">{allergies.length}</div>
               <div className="pet-profile-stat-label">Allergies</div>
             </div>
             <div className="pet-profile-stat" onClick={() => navigate('health#medications')}>
-              <div className="pet-profile-stat-value text-info">{medications.filter(m => m.is_active).length}</div>
+              <div className="pet-profile-stat-value text-navy">{medications.filter(m => m.is_active).length}</div>
               <div className="pet-profile-stat-label">Medications</div>
             </div>
             <div className="pet-profile-stat" onClick={() => navigate('health#vaccinations')}>
-              <div className="pet-profile-stat-value text-success">{vaccinations.length}</div>
+              <div className="pet-profile-stat-value text-navy">{vaccinations.length}</div>
               <div className="pet-profile-stat-label">Vaccinations</div>
             </div>
           </div>
 
           {/* Mobile toggle - only visible < lg */}
           <button
-            className="lg:hidden w-full flex items-center justify-between p-3 rounded-lg bg-navy border border-surface-700 mb-2"
+            className="lg:hidden w-full flex items-center justify-between p-3 rounded-lg bg-surface-100 border border-surface-200 mb-2"
             onClick={() => setCardPreviewOpen(!cardPreviewOpen)}
           >
-            <span className="text-xs font-semibold uppercase tracking-wide text-surface-400">Card Preview</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-surface-600">Card Preview</span>
             <svg
               width="16"
               height="16"
@@ -61,7 +61,7 @@ export default function OverviewSection() {
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
-              className={`transition-transform text-surface-400 ${cardPreviewOpen ? 'rotate-180' : ''}`}
+              className={`transition-transform text-surface-600 ${cardPreviewOpen ? 'rotate-180' : ''}`}
             >
               <polyline points="6 9 12 15 18 9" />
             </svg>

--- a/frontend/src/pages/pet-profile/sections/OverviewSection.tsx
+++ b/frontend/src/pages/pet-profile/sections/OverviewSection.tsx
@@ -3,9 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { usePetProfileContext } from '../context';
 import OverviewTab from '../tabs/OverviewTab';
 import EmergencyCardPreview from '../EmergencyCardPreview';
-import PhotoUpload from '../../../components/PhotoUpload';
 import CardAlertsModal from '../../../components/CardAlertsModal';
-import { formatWeight } from '../utils';
 
 export default function OverviewSection() {
   const ctx = usePetProfileContext();
@@ -13,6 +11,7 @@ export default function OverviewSection() {
   const { pet, petId, token, vets, conditions, setConditions, allergies, setAllergies, medications, setMedications, vaccinations, setVaccinations, alerts, setAlerts, emergencyContacts, handlePetUpdated } = ctx;
 
   const [showCardAlertsModal, setShowCardAlertsModal] = useState(false);
+  const [cardPreviewOpen, setCardPreviewOpen] = useState(false);
 
   return (
     <div className="space-y-6 fade-in">
@@ -20,41 +19,6 @@ export default function OverviewSection() {
       <div className="pet-profile-overview-grid">
         {/* Left: Pet info card */}
         <div className="card">
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '16px', marginBottom: '24px' }}>
-            <PhotoUpload
-              petId={petId}
-              currentPhotoUrl={pet.photo_url}
-              onPhotoUpdated={(photoUrl) => handlePetUpdated({ ...pet, photo_url: photoUrl })}
-              compact
-              species={pet.species}
-            />
-            <div style={{ textAlign: 'center' }}>
-              <h2 style={{ fontFamily: 'var(--font-heading)', fontSize: '1.5rem', fontWeight: 700, color: 'var(--color-navy)' }}>
-                {pet.name}
-              </h2>
-              <p className="capitalize" style={{ color: 'var(--color-surface-500)', marginTop: '2px' }}>
-                {pet.breed ? `${pet.breed} \u2022 ${pet.species}` : pet.species}
-                {pet.color_markings && ` \u2022 ${pet.color_markings}`}
-                {(() => {
-                  if (pet.date_of_birth) {
-                    const age = Math.floor((Date.now() - new Date(pet.date_of_birth).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
-                    return ` \u2022 ${age} ${age === 1 ? 'year' : 'years'}`;
-                  }
-                  if (pet.age != null) {
-                    return ` \u2022 ${pet.age} ${pet.age === 1 ? 'year' : 'years'}`;
-                  }
-                  return null;
-                })()}
-                {pet.sex && ` \u2022 ${pet.sex}${pet.is_fixed ? ' (Fixed)' : ''}`}
-              </p>
-              {pet.weight_kg && (
-                <p className="text-sm" style={{ color: 'var(--color-surface-400)', marginTop: '4px' }}>
-                  {formatWeight(pet.weight_kg, pet.weight_unit)}
-                </p>
-              )}
-            </div>
-          </div>
-
           <OverviewTab
             pet={pet}
             token={token}
@@ -67,39 +31,77 @@ export default function OverviewSection() {
           {/* Stat blocks */}
           <div className="pet-profile-stats">
             <div className="pet-profile-stat" onClick={() => navigate('health#conditions')}>
-              <div className="pet-profile-stat-value" style={{ color: 'var(--color-warning)' }}>{conditions.length}</div>
+              <div className="pet-profile-stat-value text-warning">{conditions.length}</div>
               <div className="pet-profile-stat-label">Conditions</div>
             </div>
             <div className="pet-profile-stat" onClick={() => navigate('health#allergies')}>
-              <div className="pet-profile-stat-value" style={{ color: 'var(--color-danger)' }}>{allergies.length}</div>
+              <div className="pet-profile-stat-value text-danger">{allergies.length}</div>
               <div className="pet-profile-stat-label">Allergies</div>
             </div>
             <div className="pet-profile-stat" onClick={() => navigate('health#medications')}>
-              <div className="pet-profile-stat-value" style={{ color: 'var(--color-info)' }}>{medications.filter(m => m.is_active).length}</div>
+              <div className="pet-profile-stat-value text-info">{medications.filter(m => m.is_active).length}</div>
               <div className="pet-profile-stat-label">Medications</div>
             </div>
             <div className="pet-profile-stat" onClick={() => navigate('health#vaccinations')}>
-              <div className="pet-profile-stat-value" style={{ color: 'var(--color-success)' }}>{vaccinations.length}</div>
+              <div className="pet-profile-stat-value text-success">{vaccinations.length}</div>
               <div className="pet-profile-stat-label">Vaccinations</div>
             </div>
           </div>
 
-          {/* Preview header */}
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
-            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400" style={{ margin: 0 }}>Preview</p>
-            <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-blue-600 hover:text-blue-800">Edit</button>
-          </div>
+          {/* Mobile toggle - only visible < lg */}
+          <button
+            className="lg:hidden w-full flex items-center justify-between p-3 rounded-lg bg-navy border border-surface-700 mb-2"
+            onClick={() => setCardPreviewOpen(!cardPreviewOpen)}
+          >
+            <span className="text-xs font-semibold uppercase tracking-wide text-surface-400">Card Preview</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className={`transition-transform text-surface-400 ${cardPreviewOpen ? 'rotate-180' : ''}`}
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+          {cardPreviewOpen && (
+            <div className="lg:hidden mb-2">
+              <div className="flex justify-between items-center mb-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-surface-400 m-0">Preview</p>
+                <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-info hover:text-info">Edit</button>
+              </div>
+              <EmergencyCardPreview
+                pet={pet}
+                conditions={conditions}
+                allergies={allergies}
+                medications={medications}
+                vaccinations={vaccinations}
+                alerts={alerts}
+                contacts={emergencyContacts}
+                vets={vets}
+              />
+            </div>
+          )}
 
-          <EmergencyCardPreview
-            pet={pet}
-            conditions={conditions}
-            allergies={allergies}
-            medications={medications}
-            vaccinations={vaccinations}
-            alerts={alerts}
-            contacts={emergencyContacts}
-            vets={vets}
-          />
+          {/* Desktop - always visible */}
+          <div className="hidden lg:block">
+            <div className="flex justify-between items-center mb-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-surface-400 m-0">Preview</p>
+              <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-info hover:text-info">Edit</button>
+            </div>
+            <EmergencyCardPreview
+              pet={pet}
+              conditions={conditions}
+              allergies={allergies}
+              medications={medications}
+              vaccinations={vaccinations}
+              alerts={alerts}
+              contacts={emergencyContacts}
+              vets={vets}
+            />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/pet-profile/sections/OverviewSection.tsx
+++ b/frontend/src/pages/pet-profile/sections/OverviewSection.tsx
@@ -27,7 +27,7 @@ export default function OverviewSection() {
         </div>
 
         {/* Right: Stat blocks + Emergency card preview */}
-        <div>
+        <div className="flex flex-col">
           {/* Stat blocks */}
           <div className="pet-profile-stats">
             <div className="pet-profile-stat" onClick={() => navigate('health#conditions')}>
@@ -68,9 +68,9 @@ export default function OverviewSection() {
           </button>
           {cardPreviewOpen && (
             <div className="lg:hidden mb-2">
-              <div className="flex justify-between items-center mb-2">
+              <div className="flex justify-between items-center mb-3">
                 <p className="text-xs font-semibold uppercase tracking-wide text-surface-400 m-0">Preview</p>
-                <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-info hover:text-info">Edit</button>
+                <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-steel hover:text-steel-dark">Edit</button>
               </div>
               <EmergencyCardPreview
                 pet={pet}
@@ -87,9 +87,9 @@ export default function OverviewSection() {
 
           {/* Desktop - always visible */}
           <div className="hidden lg:block">
-            <div className="flex justify-between items-center mb-2">
+            <div className="flex justify-between items-center mb-3">
               <p className="text-xs font-semibold uppercase tracking-wide text-surface-400 m-0">Preview</p>
-              <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-info hover:text-info">Edit</button>
+              <button onClick={() => setShowCardAlertsModal(true)} className="text-xs font-medium text-steel hover:text-steel-dark">Edit</button>
             </div>
             <EmergencyCardPreview
               pet={pet}

--- a/frontend/src/pages/pet-profile/tabs/AlertsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/AlertsTab.tsx
@@ -1,5 +1,6 @@
 import { useState, SetStateAction } from 'react';
 import { petsApi, PetCondition, PetAllergy, PetMedication, PetVaccination } from '../../../api/client';
+import EmptyState from '../../../components/EmptyState';
 import { useFieldSet } from '../../../hooks/useFieldToggle';
 
 type DropdownValue = '' | `condition-${number}` | `allergy-${number}` | `medication-${number}` | `vaccination-${number}`;
@@ -72,10 +73,10 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
       {/* Section A: On Card */}
       <div>
         <h3 className="text-base font-semibold mb-1">On Card</h3>
-        <p className="text-sm text-gray-500 mb-3">Items currently shown on the emergency card</p>
+        <p className="text-sm text-surface-500 mb-3">Items currently shown on the emergency card</p>
 
         {totalOnCard === 0 ? (
-          <p className="text-gray-400 text-sm text-center py-4 border border-dashed rounded-lg">No items on card yet</p>
+          <EmptyState title="No alerts configured" compact />
         ) : (
           <div className="space-y-3">
             {conditionsOnCard.length > 0 && (
@@ -86,11 +87,11 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
                     <li key={c.id} className="px-3 py-2 flex justify-between items-center">
                       <div>
                         <p className="text-sm font-medium">{c.name}</p>
-                        {c.severity && <span className="text-xs text-gray-500 capitalize">{c.severity}</span>}
+                        {c.severity && <span className="text-xs text-surface-500 capitalize">{c.severity}</span>}
                       </div>
                       <button
                         onClick={() => handleRemoveCondition(c)}
-                        className="text-gray-400 hover:text-red-600 text-sm ml-3 flex-shrink-0"
+                        className="text-surface-400 hover:text-danger text-sm ml-3 flex-shrink-0"
                         title="Remove from card"
                       >
                         &times;
@@ -103,21 +104,21 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
 
             {allergiesOnCard.length > 0 && (
               <div>
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-red-700 mb-1">Allergies</h4>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-danger mb-1">Allergies</h4>
                 <ul className="divide-y border rounded-lg">
                   {allergiesOnCard.map(a => (
                     <li key={a.id} className="px-3 py-2 flex justify-between items-center">
                       <div>
                         <p className="text-sm font-medium">{a.allergen}</p>
                         {a.severity && (
-                          <span className={`text-xs capitalize ${a.severity === 'life-threatening' ? 'text-red-600 font-semibold' : 'text-gray-500'}`}>
+                          <span className={`text-xs capitalize ${a.severity === 'life-threatening' ? 'text-danger font-semibold' : 'text-surface-500'}`}>
                             {a.severity}
                           </span>
                         )}
                       </div>
                       <button
                         onClick={() => handleRemoveAllergy(a)}
-                        className="text-gray-400 hover:text-red-600 text-sm ml-3 flex-shrink-0"
+                        className="text-surface-400 hover:text-danger text-sm ml-3 flex-shrink-0"
                         title="Remove from card"
                       >
                         &times;
@@ -130,17 +131,17 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
 
             {medicationsOnCard.length > 0 && (
               <div>
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-blue-700 mb-1">Medications</h4>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-info mb-1">Medications</h4>
                 <ul className="divide-y border rounded-lg">
                   {medicationsOnCard.map(m => (
                     <li key={m.id} className="px-3 py-2 flex justify-between items-center">
                       <div>
                         <p className="text-sm font-medium">{m.name}</p>
-                        {m.dosage && <span className="text-xs text-gray-500">{m.dosage}</span>}
+                        {m.dosage && <span className="text-xs text-surface-500">{m.dosage}</span>}
                       </div>
                       <button
                         onClick={() => handleRemoveMedication(m)}
-                        className="text-gray-400 hover:text-red-600 text-sm ml-3 flex-shrink-0"
+                        className="text-surface-400 hover:text-danger text-sm ml-3 flex-shrink-0"
                         title="Remove from card"
                       >
                         &times;
@@ -153,14 +154,14 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
 
             {vaccinationsOnCard.length > 0 && (
               <div>
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-green-700 mb-1">Vaccinations</h4>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-success mb-1">Vaccinations</h4>
                 <ul className="divide-y border rounded-lg">
                   {vaccinationsOnCard.map(v => (
                     <li key={v.id} className="px-3 py-2 flex justify-between items-center">
                       <p className="text-sm font-medium">{v.name}</p>
                       <button
                         onClick={() => handleRemoveVaccination(v)}
-                        className="text-gray-400 hover:text-red-600 text-sm ml-3 flex-shrink-0"
+                        className="text-surface-400 hover:text-danger text-sm ml-3 flex-shrink-0"
                         title="Remove from card"
                       >
                         &times;
@@ -177,7 +178,7 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
       {/* Section B: Add to Card */}
       <div>
         <h3 className="text-base font-semibold mb-1">Add to Card</h3>
-        <p className="text-sm text-gray-500 mb-3">Select a health record to show on the emergency card</p>
+        <p className="text-sm text-surface-500 mb-3">Select a health record to show on the emergency card</p>
 
         {hasAnyCandidates ? (
           <select
@@ -228,7 +229,7 @@ export default function AlertsTab({ petId, token, conditions, setConditions, all
             )}
           </select>
         ) : (
-          <p className="text-gray-400 text-sm text-center py-4 border border-dashed rounded-lg">
+          <p className="text-surface-400 text-sm text-center py-4 border border-dashed rounded-lg">
             All eligible health records are already on the card
           </p>
         )}

--- a/frontend/src/pages/pet-profile/tabs/AllergiesTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/AllergiesTab.tsx
@@ -2,6 +2,7 @@ import { useState, SetStateAction } from 'react';
 import { petsApi, PetAllergy } from '../../../api/client';
 import InlineEditForm from '../../../components/InlineEditForm';
 import SourceDocumentLink from '../../../components/SourceDocumentLink';
+import EmptyState from '../../../components/EmptyState';
 import { useFieldToggle } from '../../../hooks/useFieldToggle';
 import { ALLERGY_FIELDS } from '../constants';
 
@@ -44,7 +45,7 @@ export default function AllergiesTab({ petId, token, allergies, setAllergies, on
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Allergies</h3>
+        <h3 className="section-title">Allergies</h3>
         <button onClick={() => setShowForm(!showForm)} className="btn-primary text-sm">+ Add Allergy</button>
       </div>
 
@@ -59,7 +60,7 @@ export default function AllergiesTab({ petId, token, allergies, setAllergies, on
       )}
 
       {allergies.length === 0 ? (
-        <p className="text-gray-500 text-center py-8">No allergies recorded</p>
+        <EmptyState title="No allergies recorded" compact />
       ) : (
         <ul className="divide-y">
           {allergies.map(a => (
@@ -77,26 +78,26 @@ export default function AllergiesTab({ petId, token, allergies, setAllergies, on
                     <div className="flex items-center gap-2">
                       <p className="font-medium">{a.allergen}</p>
                       {a.show_on_card && (
-                        <span className="text-[10px] bg-red-100 text-red-700 px-1.5 py-0.5 rounded font-semibold">ALERT</span>
+                        <span className="text-[10px] bg-danger-light text-danger px-1.5 py-0.5 rounded font-semibold">ALERT</span>
                       )}
                     </div>
-                    {a.severity && <span className={`text-sm capitalize ${a.severity === 'life-threatening' ? 'text-red-600 font-semibold' : 'text-gray-500'}`}>{a.severity}</span>}
-                    {a.reaction && <p className="text-sm text-gray-600 mt-1">Reaction: {a.reaction}</p>}
+                    {a.severity && <span className={`text-sm capitalize ${a.severity === 'life-threatening' ? 'text-danger font-semibold' : 'text-surface-500'}`}>{a.severity}</span>}
+                    {a.reaction && <p className="text-sm text-surface-600 mt-1">Reaction: {a.reaction}</p>}
                     <SourceDocumentLink petId={petId} recordType="pet_allergies" recordId={a.id} onNavigateToReview={onNavigateToReview} />
                   </div>
                   <div className="flex gap-2">
-                    <button onClick={() => handleToggleShowOnCard(a)} className={`text-sm ${a.show_on_card ? 'text-red-600 hover:text-red-800' : 'text-gray-400 hover:text-gray-600'}`} title={a.show_on_card ? 'Remove from card' : 'Show on card'}>
+                    <button onClick={() => handleToggleShowOnCard(a)} className={`text-sm ${a.show_on_card ? 'text-danger hover:text-danger-dark' : 'text-surface-400 hover:text-surface-600'}`} title={a.show_on_card ? 'Remove from card' : 'Show on card'}>
                       {a.show_on_card ? '\u{1F514}' : '\u{1F515}'}
                     </button>
                     <button onClick={() => setEditingId(a.id)} className="text-navy hover:text-primary-800 text-sm">Edit</button>
                     {deletingId === a.id ? (
                       <>
-                        <span className="text-sm text-gray-500">Sure?</span>
-                        <button onClick={() => handleDelete(a.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
-                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                        <span className="text-sm text-surface-500">Sure?</span>
+                        <button onClick={() => handleDelete(a.id)} className="text-danger hover:text-danger-dark text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-surface-600 hover:text-navy text-sm">No</button>
                       </>
                     ) : (
-                      <button onClick={() => setDeletingId(a.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                      <button onClick={() => setDeletingId(a.id)} className="text-danger hover:text-danger-dark text-sm">Delete</button>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/pet-profile/tabs/ConditionsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/ConditionsTab.tsx
@@ -3,6 +3,7 @@ import { petsApi, PetCondition } from '../../../api/client';
 import InlineEditForm from '../../../components/InlineEditForm';
 import { formatFlexibleDate } from '../../../components/FlexibleDateInput';
 import SourceDocumentLink from '../../../components/SourceDocumentLink';
+import EmptyState from '../../../components/EmptyState';
 import { useFieldToggle } from '../../../hooks/useFieldToggle';
 import { CONDITION_FIELDS } from '../constants';
 
@@ -74,32 +75,32 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
             <div className="flex items-center gap-2">
               <p className={`font-medium ${isInactive ? 'line-through' : ''}`}>{c.name}</p>
               {c.show_on_card && (
-                <span className="text-[10px] bg-red-100 text-red-700 px-1.5 py-0.5 rounded font-semibold">ALERT</span>
+                <span className="text-[10px] bg-danger-light text-danger px-1.5 py-0.5 rounded font-semibold">ALERT</span>
               )}
             </div>
-            <div className="flex gap-2 text-sm text-gray-500">
+            <div className="flex gap-2 text-sm text-surface-500">
               {c.severity && <span className="capitalize">{c.severity}</span>}
               {c.diagnosed_date && <span>Diagnosed: {formatFlexibleDate(c.diagnosed_date, c.diagnosed_date_precision)}</span>}
             </div>
-            {c.notes && <p className="text-sm text-gray-600 mt-1">{c.notes}</p>}
+            {c.notes && <p className="text-sm text-surface-600 mt-1">{c.notes}</p>}
             <SourceDocumentLink petId={petId} recordType="pet_conditions" recordId={c.id} onNavigateToReview={onNavigateToReview} />
           </div>
           <div className="flex gap-2 flex-shrink-0">
-            <button onClick={() => handleToggleShowOnCard(c)} className={`text-sm ${c.show_on_card ? 'text-red-600 hover:text-red-800' : 'text-gray-400 hover:text-gray-600'}`} title={c.show_on_card ? 'Remove from card' : 'Show on card'}>
+            <button onClick={() => handleToggleShowOnCard(c)} className={`text-sm ${c.show_on_card ? 'text-danger hover:text-danger-dark' : 'text-surface-400 hover:text-surface-600'}`} title={c.show_on_card ? 'Remove from card' : 'Show on card'}>
               {c.show_on_card ? '\u{1F514}' : '\u{1F515}'}
             </button>
             <button onClick={() => setEditingId(c.id)} className="text-navy hover:text-primary-800 text-sm">Edit</button>
-            <button onClick={() => handleToggleActive(c)} className={`text-sm ${isInactive ? 'text-navy hover:text-primary-800' : 'text-gray-600 hover:text-gray-800'}`}>
+            <button onClick={() => handleToggleActive(c)} className={`text-sm ${isInactive ? 'text-navy hover:text-primary-800' : 'text-surface-600 hover:text-navy'}`}>
               {isInactive ? 'Reactivate' : 'Discontinue'}
             </button>
             {deletingId === c.id ? (
               <>
-                <span className="text-sm text-gray-500">Sure?</span>
-                <button onClick={() => handleDelete(c.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
-                <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                <span className="text-sm text-surface-500">Sure?</span>
+                <button onClick={() => handleDelete(c.id)} className="text-danger hover:text-danger-dark text-sm font-semibold">Yes</button>
+                <button onClick={() => setDeletingId(null)} className="text-surface-600 hover:text-navy text-sm">No</button>
               </>
             ) : (
-              <button onClick={() => setDeletingId(c.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+              <button onClick={() => setDeletingId(c.id)} className="text-danger hover:text-danger-dark text-sm">Delete</button>
             )}
           </div>
         </div>
@@ -110,7 +111,7 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Medical Conditions</h3>
+        <h3 className="section-title">Medical Conditions</h3>
         <button onClick={() => setShowForm(!showForm)} className="btn-primary text-sm">+ Add Condition</button>
       </div>
 
@@ -126,7 +127,7 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
 
       {active.length > 0 && (
         <div className="mb-6">
-          <h4 className="text-sm font-medium text-gray-500 mb-2">Active Conditions</h4>
+          <h4 className="text-sm font-medium text-surface-500 mb-2">Active Conditions</h4>
           <ul className="divide-y border rounded-lg">
             {active.map(c => renderConditionRow(c))}
           </ul>
@@ -135,7 +136,7 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
 
       {inactive.length > 0 && (
         <div>
-          <h4 className="text-sm font-medium text-gray-500 mb-2">Discontinued Conditions</h4>
+          <h4 className="text-sm font-medium text-surface-500 mb-2">Discontinued Conditions</h4>
           <ul className="divide-y border rounded-lg opacity-60">
             {inactive.map(c => renderConditionRow(c, true))}
           </ul>
@@ -143,7 +144,7 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
       )}
 
       {conditions.length === 0 && (
-        <p className="text-gray-500 text-center py-8">No medical conditions recorded</p>
+        <EmptyState title="No medical conditions recorded" compact />
       )}
     </div>
   );

--- a/frontend/src/pages/pet-profile/tabs/ConditionsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/ConditionsTab.tsx
@@ -128,7 +128,7 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
       {active.length > 0 && (
         <div className="mb-6">
           <h4 className="text-sm font-medium text-surface-500 mb-2">Active Conditions</h4>
-          <ul className="divide-y border rounded-lg">
+          <ul className="divide-y divide-surface-200 border border-surface-200 rounded-lg">
             {active.map(c => renderConditionRow(c))}
           </ul>
         </div>
@@ -137,7 +137,7 @@ export default function ConditionsTab({ petId, token, conditions, setConditions,
       {inactive.length > 0 && (
         <div>
           <h4 className="text-sm font-medium text-surface-500 mb-2">Discontinued Conditions</h4>
-          <ul className="divide-y border rounded-lg opacity-60">
+          <ul className="divide-y divide-surface-200 border border-surface-200 rounded-lg opacity-60">
             {inactive.map(c => renderConditionRow(c, true))}
           </ul>
         </div>

--- a/frontend/src/pages/pet-profile/tabs/ContactsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/ContactsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { petsApi, PetEmergencyContact } from '../../../api/client';
 import InlineEditForm from '../../../components/InlineEditForm';
+import EmptyState from '../../../components/EmptyState';
 import { CONTACT_FIELDS } from '../constants';
 
 export default function ContactsTab({ petId, token, contacts, setContacts }: {
@@ -45,7 +46,7 @@ export default function ContactsTab({ petId, token, contacts, setContacts }: {
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Emergency Contacts</h3>
+        <h3 className="section-title">Emergency Contacts</h3>
         <button onClick={() => setShowForm(!showForm)} className="btn-primary text-sm">+ Add Contact</button>
       </div>
 
@@ -60,7 +61,7 @@ export default function ContactsTab({ petId, token, contacts, setContacts }: {
       )}
 
       {contacts.length === 0 ? (
-        <p className="text-gray-500 text-center py-8">No emergency contacts recorded</p>
+        <EmptyState title="No emergency contacts recorded" compact />
       ) : (
         <ul className="divide-y">
           {contacts.map(c => (
@@ -76,8 +77,8 @@ export default function ContactsTab({ petId, token, contacts, setContacts }: {
                 <div className="flex justify-between items-start">
                   <div>
                     <p className="font-medium">{c.name} {c.is_primary && <span className="text-xs bg-navy-50 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
-                    {c.relationship && <p className="text-sm text-gray-600">{c.relationship}</p>}
-                    <p className="text-sm text-gray-500">{c.phone}</p>
+                    {c.relationship && <p className="text-sm text-surface-600">{c.relationship}</p>}
+                    <p className="text-sm text-surface-500">{c.phone}</p>
                   </div>
                   <div className="flex gap-2">
                     <button onClick={() => setEditingId(c.id)} className="text-navy hover:text-primary-800 text-sm">Edit</button>
@@ -91,12 +92,12 @@ export default function ContactsTab({ petId, token, contacts, setContacts }: {
                     )}
                     {deletingId === c.id ? (
                       <>
-                        <span className="text-sm text-gray-500">Sure?</span>
-                        <button onClick={() => handleDelete(c.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
-                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                        <span className="text-sm text-surface-500">Sure?</span>
+                        <button onClick={() => handleDelete(c.id)} className="text-danger hover:text-danger-dark text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-surface-600 hover:text-navy text-sm">No</button>
                       </>
                     ) : (
-                      <button onClick={() => setDeletingId(c.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                      <button onClick={() => setDeletingId(c.id)} className="text-danger hover:text-danger-dark text-sm">Delete</button>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/pet-profile/tabs/ContactsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/ContactsTab.tsx
@@ -63,7 +63,7 @@ export default function ContactsTab({ petId, token, contacts, setContacts }: {
       {contacts.length === 0 ? (
         <EmptyState title="No emergency contacts recorded" compact />
       ) : (
-        <ul className="divide-y">
+        <ul className="divide-y divide-surface-100">
           {contacts.map(c => (
             <li key={c.id} className="py-3">
               {editingId === c.id ? (
@@ -76,7 +76,7 @@ export default function ContactsTab({ petId, token, contacts, setContacts }: {
               ) : (
                 <div className="flex justify-between items-start">
                   <div>
-                    <p className="font-medium">{c.name} {c.is_primary && <span className="text-xs bg-navy-50 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
+                    <p className="font-medium">{c.name} {c.is_primary && <span className="badge badge-navy">Primary</span>}</p>
                     {c.relationship && <p className="text-sm text-surface-600">{c.relationship}</p>}
                     <p className="text-sm text-surface-500">{c.phone}</p>
                   </div>

--- a/frontend/src/pages/pet-profile/tabs/HistoryTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/HistoryTab.tsx
@@ -4,7 +4,7 @@ export default function HistoryTab({ petId }: { petId: number }) {
   return (
     <div>
       <h3 className="text-lg font-semibold mb-4">Change History</h3>
-      <p className="text-sm text-gray-600 mb-4">
+      <p className="text-sm text-surface-600 mb-4">
         View all changes made to your pet's health records, including data imported from PDFs.
       </p>
       <AuditLogViewer petId={petId} />

--- a/frontend/src/pages/pet-profile/tabs/ImagesTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/ImagesTab.tsx
@@ -10,11 +10,11 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
   if (images.length === 0) {
     return (
       <div className="text-center py-12">
-        <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg className="mx-auto h-12 w-12 text-surface-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
-        <h3 className="mt-2 text-sm font-medium text-gray-900">No images yet</h3>
-        <p className="mt-1 text-sm text-gray-500">
+        <h3 className="mt-2 text-sm font-medium text-navy">No images yet</h3>
+        <p className="mt-1 text-sm text-surface-500">
           Upload images from the Import Documents tab.
         </p>
       </div>
@@ -24,9 +24,9 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">
+        <h3 className="text-lg font-semibold text-navy">
           Images
-          <span className="ml-2 text-sm font-normal text-gray-500">({images.length})</span>
+          <span className="ml-2 text-sm font-normal text-surface-500">({images.length})</span>
         </h3>
       </div>
 
@@ -34,7 +34,7 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
         {images.map((img) => (
           <div
             key={img.id}
-            className="group relative bg-gray-100 rounded-lg overflow-hidden cursor-pointer border border-gray-200 hover:border-blue-400 hover:shadow-md transition-all"
+            className="group relative bg-surface-100 rounded-lg overflow-hidden cursor-pointer border border-surface-200 hover:border-info hover:shadow-md transition-all"
             onClick={() => setSelectedImage(img)}
           >
             <div className="aspect-square">
@@ -46,23 +46,23 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
               />
             </div>
             <div className="p-2">
-              <p className="text-sm font-medium text-gray-900 truncate">
+              <p className="text-sm font-medium text-navy truncate">
                 {img.user_tag || img.original_filename}
               </p>
               <div className="flex items-center gap-2 mt-0.5">
                 {img.date_taken && (
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-surface-500">
                     {new Date(img.date_taken).toLocaleDateString()}
                   </p>
                 )}
                 {img.body_area && (
-                  <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+                  <span className="text-xs bg-surface-100 text-surface-600 px-1.5 py-0.5 rounded">
                     {img.body_area}
                   </span>
                 )}
               </div>
               {img.user_description && (
-                <p className="text-xs text-gray-500 mt-1 truncate">{img.user_description}</p>
+                <p className="text-xs text-surface-500 mt-1 truncate">{img.user_description}</p>
               )}
             </div>
           </div>
@@ -80,14 +80,14 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
           >
             <button
               onClick={() => setSelectedImage(null)}
-              className="absolute top-3 right-3 z-10 bg-white bg-opacity-90 rounded-full p-1.5 text-gray-600 hover:text-gray-900 hover:bg-opacity-100 shadow-sm"
+              className="absolute top-3 right-3 z-10 bg-white bg-opacity-90 rounded-full p-1.5 text-surface-600 hover:text-navy hover:bg-opacity-100 shadow-sm"
             >
               <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
 
-            <div className="flex items-center justify-center bg-gray-900 max-h-[70vh]">
+            <div className="flex items-center justify-center bg-navy max-h-[70vh]">
               <img
                 src={getImageUrl(selectedImage)}
                 alt={selectedImage.user_tag || selectedImage.original_filename}
@@ -96,13 +96,13 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
             </div>
 
             <div className="p-4 border-t">
-              <h4 className="font-medium text-gray-900">
+              <h4 className="font-medium text-navy">
                 {selectedImage.user_tag || selectedImage.original_filename}
               </h4>
               {selectedImage.user_description && (
-                <p className="text-sm text-gray-600 mt-1">{selectedImage.user_description}</p>
+                <p className="text-sm text-surface-600 mt-1">{selectedImage.user_description}</p>
               )}
-              <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
+              <div className="flex flex-wrap gap-3 mt-2 text-sm text-surface-500">
                 {selectedImage.date_taken && (
                   <span>Date: {new Date(selectedImage.date_taken).toLocaleDateString()}</span>
                 )}
@@ -116,7 +116,7 @@ export default function ImagesTab({ petId, images }: { petId: number; images: Do
                   href={getImageUrl(selectedImage)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-blue-600 hover:text-blue-700 hover:underline"
+                  className="text-sm text-info hover:text-info hover:underline"
                 >
                   Open full size
                 </a>

--- a/frontend/src/pages/pet-profile/tabs/MedicationsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/MedicationsTab.tsx
@@ -3,6 +3,7 @@ import { petsApi, PetMedication } from '../../../api/client';
 import InlineEditForm from '../../../components/InlineEditForm';
 import { formatFlexibleDate } from '../../../components/FlexibleDateInput';
 import SourceDocumentLink from '../../../components/SourceDocumentLink';
+import EmptyState from '../../../components/EmptyState';
 import { useFieldToggle } from '../../../hooks/useFieldToggle';
 import { MEDICATION_FIELDS } from '../constants';
 
@@ -69,30 +70,30 @@ export default function MedicationsTab({ petId, token, medications, setMedicatio
             <div className="flex items-center gap-2">
               <p className={`font-medium ${isInactive ? 'line-through' : ''}`}>{m.name}</p>
               {m.show_on_card && (
-                <span className="text-[10px] bg-red-100 text-red-700 px-1.5 py-0.5 rounded font-semibold">ALERT</span>
+                <span className="text-[10px] bg-danger-light text-danger px-1.5 py-0.5 rounded font-semibold">ALERT</span>
               )}
             </div>
-            {m.dosage && <span className="text-sm text-gray-500">{m.dosage}</span>}
-            {m.frequency && <span className="text-sm text-gray-500"> - {m.frequency}</span>}
-            {m.start_date && <p className="text-sm text-gray-500">Started: {formatFlexibleDate(m.start_date, m.start_date_precision)}</p>}
+            {m.dosage && <span className="text-sm text-surface-500">{m.dosage}</span>}
+            {m.frequency && <span className="text-sm text-surface-500"> - {m.frequency}</span>}
+            {m.start_date && <p className="text-sm text-surface-500">Started: {formatFlexibleDate(m.start_date, m.start_date_precision)}</p>}
             <SourceDocumentLink petId={petId} recordType="pet_medications" recordId={m.id} onNavigateToReview={onNavigateToReview} />
           </div>
           <div className="flex gap-2">
-            <button onClick={() => handleToggleShowOnCard(m)} className={`text-sm ${m.show_on_card ? 'text-red-600 hover:text-red-800' : 'text-gray-400 hover:text-gray-600'}`} title={m.show_on_card ? 'Remove from card' : 'Show on card'}>
+            <button onClick={() => handleToggleShowOnCard(m)} className={`text-sm ${m.show_on_card ? 'text-danger hover:text-danger-dark' : 'text-surface-400 hover:text-surface-600'}`} title={m.show_on_card ? 'Remove from card' : 'Show on card'}>
               {m.show_on_card ? '\u{1F514}' : '\u{1F515}'}
             </button>
             <button onClick={() => setEditingId(m.id)} className="text-navy hover:text-primary-800 text-sm">Edit</button>
-            <button onClick={() => handleToggleActive(m)} className={`text-sm ${isInactive ? 'text-navy hover:text-primary-800' : 'text-gray-600 hover:text-gray-800'}`}>
+            <button onClick={() => handleToggleActive(m)} className={`text-sm ${isInactive ? 'text-navy hover:text-primary-800' : 'text-surface-600 hover:text-navy'}`}>
               {isInactive ? 'Reactivate' : 'Discontinue'}
             </button>
             {deletingId === m.id ? (
               <>
-                <span className="text-sm text-gray-500">Sure?</span>
-                <button onClick={() => handleDelete(m.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
-                <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                <span className="text-sm text-surface-500">Sure?</span>
+                <button onClick={() => handleDelete(m.id)} className="text-danger hover:text-danger-dark text-sm font-semibold">Yes</button>
+                <button onClick={() => setDeletingId(null)} className="text-surface-600 hover:text-navy text-sm">No</button>
               </>
             ) : (
-              <button onClick={() => setDeletingId(m.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+              <button onClick={() => setDeletingId(m.id)} className="text-danger hover:text-danger-dark text-sm">Delete</button>
             )}
           </div>
         </div>
@@ -103,7 +104,7 @@ export default function MedicationsTab({ petId, token, medications, setMedicatio
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Medications</h3>
+        <h3 className="section-title">Medications</h3>
         <button onClick={() => setShowForm(!showForm)} className="btn-primary text-sm">+ Add Medication</button>
       </div>
 
@@ -119,7 +120,7 @@ export default function MedicationsTab({ petId, token, medications, setMedicatio
 
       {active.length > 0 && (
         <div className="mb-6">
-          <h4 className="text-sm font-medium text-gray-500 mb-2">Active Medications</h4>
+          <h4 className="text-sm font-medium text-surface-500 mb-2">Active Medications</h4>
           <ul className="divide-y border rounded-lg">
             {active.map(m => renderMedRow(m))}
           </ul>
@@ -128,7 +129,7 @@ export default function MedicationsTab({ petId, token, medications, setMedicatio
 
       {inactive.length > 0 && (
         <div>
-          <h4 className="text-sm font-medium text-gray-500 mb-2">Past Medications</h4>
+          <h4 className="text-sm font-medium text-surface-500 mb-2">Past Medications</h4>
           <ul className="divide-y border rounded-lg opacity-60">
             {inactive.map(m => renderMedRow(m, true))}
           </ul>
@@ -136,7 +137,7 @@ export default function MedicationsTab({ petId, token, medications, setMedicatio
       )}
 
       {medications.length === 0 && (
-        <p className="text-gray-500 text-center py-8">No medications recorded</p>
+        <EmptyState title="No medications recorded" compact />
       )}
     </div>
   );

--- a/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
@@ -110,7 +110,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
       const config = fieldConfigs[field];
       return (
         <div className="col-span-2">
-          <dt className="text-sm text-gray-500 mb-1">{label}</dt>
+          <dt className="text-sm text-surface-500 mb-1">{label}</dt>
           <InlineEditForm
             fields={config.fields}
             values={config.values}
@@ -123,16 +123,16 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
 
     return (
       <div
-        className="group cursor-pointer rounded-lg p-2 -m-2 hover:bg-gray-50 transition-colors"
+        className="group cursor-pointer rounded-lg p-2 -m-2 hover:bg-surface transition-colors"
         onClick={() => setEditingField(field)}
       >
-        <dt className="text-sm text-gray-500 flex items-center gap-1">
+        <dt className="text-sm text-surface-500 flex items-center gap-1">
           {label}
-          <svg className="w-3 h-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-3 h-3 text-surface-400 opacity-0 group-hover:opacity-100 transition-opacity" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
           </svg>
         </dt>
-        <dd className="text-gray-900">{displayValue}</dd>
+        <dd className="text-navy">{displayValue}</dd>
       </div>
     );
   };
@@ -142,8 +142,8 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
       const calculatedAge = Math.floor((Date.now() - new Date(pet.date_of_birth).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
       return (
         <div>
-          <dt className="text-sm text-gray-500">Age</dt>
-          <dd className="text-gray-900">{calculatedAge} {calculatedAge === 1 ? 'year' : 'years'}</dd>
+          <dt className="text-sm text-surface-500">Age</dt>
+          <dd className="text-navy">{calculatedAge} {calculatedAge === 1 ? 'year' : 'years'}</dd>
         </div>
       );
     }
@@ -153,22 +153,22 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-3">Basic Information</h3>
+        <h3 className="text-lg font-semibold text-navy mb-3">Basic Information</h3>
         <dl className="grid grid-cols-2 gap-4">
           {renderEditableField('name', 'Name', pet.name)}
           {renderEditableField('species', 'Species', <span className="capitalize">{pet.species}</span>)}
-          {renderEditableField('breed', 'Breed', pet.breed || <span className="text-gray-400 text-sm">Add breed</span>)}
-          {renderEditableField('color_markings', 'Color / Markings', pet.color_markings || <span className="text-gray-400 text-sm">Add color or markings</span>)}
-          {renderEditableField('sex', 'Sex', pet.sex ? <span className="capitalize">{pet.sex}{pet.is_fixed ? ' (Spayed/Neutered)' : ''}</span> : <span className="text-gray-400 text-sm">Add sex</span>)}
-          {renderEditableField('date_of_birth', 'Date of Birth', pet.date_of_birth ? new Date(pet.date_of_birth.split('T')[0] + 'T00:00:00').toLocaleDateString() : <span className="text-gray-400 text-sm">Add date of birth</span>)}
+          {renderEditableField('breed', 'Breed', pet.breed || <span className="text-surface-400 text-sm">Add breed</span>)}
+          {renderEditableField('color_markings', 'Color / Markings', pet.color_markings || <span className="text-surface-400 text-sm">Add color or markings</span>)}
+          {renderEditableField('sex', 'Sex', pet.sex ? <span className="capitalize">{pet.sex}{pet.is_fixed ? ' (Spayed/Neutered)' : ''}</span> : <span className="text-surface-400 text-sm">Add sex</span>)}
+          {renderEditableField('date_of_birth', 'Date of Birth', pet.date_of_birth ? new Date(pet.date_of_birth.split('T')[0] + 'T00:00:00').toLocaleDateString() : <span className="text-surface-400 text-sm">Add date of birth</span>)}
           {renderAgeField()}
-          {renderEditableField('weight', 'Weight', pet.weight_kg ? formatWeight(pet.weight_kg, pet.weight_unit) : <span className="text-gray-400 text-sm">Add weight</span>)}
-          {renderEditableField('microchip_id', 'Microchip ID', pet.microchip_id ? <span className="font-mono">{pet.microchip_id}</span> : <span className="text-gray-400 text-sm">Add microchip ID</span>)}
+          {renderEditableField('weight', 'Weight', pet.weight_kg ? formatWeight(pet.weight_kg, pet.weight_unit) : <span className="text-surface-400 text-sm">Add weight</span>)}
+          {renderEditableField('microchip_id', 'Microchip ID', pet.microchip_id ? <span className="font-mono">{pet.microchip_id}</span> : <span className="text-surface-400 text-sm">Add microchip ID</span>)}
         </dl>
       </div>
 
       <div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-3">Owner's Notes</h3>
+        <h3 className="text-lg font-semibold text-navy mb-3">Owner's Notes</h3>
         {editingField === 'special_instructions' ? (
           <InlineEditForm
             fields={fieldConfigs.special_instructions.fields}
@@ -178,18 +178,18 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
           />
         ) : (
           <div
-            className="group cursor-pointer rounded-lg p-2 -m-2 hover:bg-gray-50 transition-colors"
+            className="group cursor-pointer rounded-lg p-2 -m-2 hover:bg-surface transition-colors"
             onClick={() => setEditingField('special_instructions')}
           >
             {pet.special_instructions ? (
-              <p className="text-gray-700 whitespace-pre-wrap flex items-start gap-1">
+              <p className="text-surface-700 whitespace-pre-wrap flex items-start gap-1">
                 {pet.special_instructions}
-                <svg className="w-3 h-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity mt-1 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="w-3 h-3 text-surface-400 opacity-0 group-hover:opacity-100 transition-opacity mt-1 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                 </svg>
               </p>
             ) : (
-              <p className="text-gray-400 text-sm">Add owner's notes</p>
+              <p className="text-surface-400 text-sm">Add owner's notes</p>
             )}
           </div>
         )}

--- a/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
@@ -110,7 +110,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
       const config = fieldConfigs[field];
       return (
         <div className="col-span-2">
-          <dt className="text-sm text-surface-500 mb-1">{label}</dt>
+          <dt className="text-xs font-medium uppercase tracking-wide text-surface-500 mb-1">{label}</dt>
           <InlineEditForm
             fields={config.fields}
             values={config.values}
@@ -123,10 +123,10 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
 
     return (
       <div
-        className="group cursor-pointer rounded-lg p-2 -m-2 hover:bg-surface transition-colors"
+        className="group cursor-pointer rounded-lg p-3 -m-3 hover:bg-warm transition-colors"
         onClick={() => setEditingField(field)}
       >
-        <dt className="text-sm text-surface-500 flex items-center gap-1">
+        <dt className="text-xs font-medium uppercase tracking-wide text-surface-500 flex items-center gap-1">
           {label}
           <svg className="w-3 h-3 text-surface-400 opacity-0 group-hover:opacity-100 transition-opacity" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
@@ -142,7 +142,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
       const calculatedAge = Math.floor((Date.now() - new Date(pet.date_of_birth).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
       return (
         <div>
-          <dt className="text-sm text-surface-500">Age</dt>
+          <dt className="text-xs font-medium uppercase tracking-wide text-surface-500">Age</dt>
           <dd className="text-navy">{calculatedAge} {calculatedAge === 1 ? 'year' : 'years'}</dd>
         </div>
       );
@@ -154,16 +154,16 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold text-navy mb-3">Basic Information</h3>
-        <dl className="grid grid-cols-2 gap-4">
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-1">
           {renderEditableField('name', 'Name', pet.name)}
           {renderEditableField('species', 'Species', <span className="capitalize">{pet.species}</span>)}
-          {renderEditableField('breed', 'Breed', pet.breed || <span className="text-surface-400 text-sm">Add breed</span>)}
-          {renderEditableField('color_markings', 'Color / Markings', pet.color_markings || <span className="text-surface-400 text-sm">Add color or markings</span>)}
-          {renderEditableField('sex', 'Sex', pet.sex ? <span className="capitalize">{pet.sex}{pet.is_fixed ? ' (Spayed/Neutered)' : ''}</span> : <span className="text-surface-400 text-sm">Add sex</span>)}
-          {renderEditableField('date_of_birth', 'Date of Birth', pet.date_of_birth ? new Date(pet.date_of_birth.split('T')[0] + 'T00:00:00').toLocaleDateString() : <span className="text-surface-400 text-sm">Add date of birth</span>)}
+          {renderEditableField('breed', 'Breed', pet.breed || <span className="text-surface-400 text-sm italic">Add breed</span>)}
+          {renderEditableField('color_markings', 'Color / Markings', pet.color_markings || <span className="text-surface-400 text-sm italic">Add color or markings</span>)}
+          {renderEditableField('sex', 'Sex', pet.sex ? <span className="capitalize">{pet.sex}{pet.is_fixed ? ' (Spayed/Neutered)' : ''}</span> : <span className="text-surface-400 text-sm italic">Add sex</span>)}
+          {renderEditableField('date_of_birth', 'Date of Birth', pet.date_of_birth ? new Date(pet.date_of_birth.split('T')[0] + 'T00:00:00').toLocaleDateString() : <span className="text-surface-400 text-sm italic">Add date of birth</span>)}
           {renderAgeField()}
-          {renderEditableField('weight', 'Weight', pet.weight_kg ? formatWeight(pet.weight_kg, pet.weight_unit) : <span className="text-surface-400 text-sm">Add weight</span>)}
-          {renderEditableField('microchip_id', 'Microchip ID', pet.microchip_id ? <span className="font-mono">{pet.microchip_id}</span> : <span className="text-surface-400 text-sm">Add microchip ID</span>)}
+          {renderEditableField('weight', 'Weight', pet.weight_kg ? formatWeight(pet.weight_kg, pet.weight_unit) : <span className="text-surface-400 text-sm italic">Add weight</span>)}
+          {renderEditableField('microchip_id', 'Microchip ID', pet.microchip_id ? <span className="font-mono">{pet.microchip_id}</span> : <span className="text-surface-400 text-sm italic">Add microchip ID</span>)}
         </dl>
       </div>
 
@@ -178,7 +178,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
           />
         ) : (
           <div
-            className="group cursor-pointer rounded-lg p-2 -m-2 hover:bg-surface transition-colors"
+            className="group cursor-pointer rounded-lg p-4 bg-warm border border-surface-200 hover:border-surface-300 transition-colors"
             onClick={() => setEditingField('special_instructions')}
           >
             {pet.special_instructions ? (
@@ -189,7 +189,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
                 </svg>
               </p>
             ) : (
-              <p className="text-surface-400 text-sm">Add owner's notes</p>
+              <p className="text-surface-400 text-sm italic">Add owner's notes</p>
             )}
           </div>
         )}

--- a/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
@@ -153,8 +153,8 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-semibold text-navy mb-3">Basic Information</h3>
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-1">
+        <h3 className="section-title mb-3">Basic Information</h3>
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
           {renderEditableField('name', 'Name', pet.name)}
           {renderEditableField('species', 'Species', <span className="capitalize">{pet.species}</span>)}
           {renderEditableField('breed', 'Breed', pet.breed || <span className="text-surface-400 text-sm italic">Add breed</span>)}
@@ -168,7 +168,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
       </div>
 
       <div>
-        <h3 className="text-lg font-semibold text-navy mb-3">Owner's Notes</h3>
+        <h3 className="section-title mb-3">Owner's Notes</h3>
         {editingField === 'special_instructions' ? (
           <InlineEditForm
             fields={fieldConfigs.special_instructions.fields}

--- a/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/OverviewTab.tsx
@@ -154,7 +154,7 @@ export default function OverviewTab({ pet, token, onPetUpdated }: {
     <div className="space-y-6">
       <div>
         <h3 className="section-title mb-3">Basic Information</h3>
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-4">
           {renderEditableField('name', 'Name', pet.name)}
           {renderEditableField('species', 'Species', <span className="capitalize">{pet.species}</span>)}
           {renderEditableField('breed', 'Breed', pet.breed || <span className="text-surface-400 text-sm italic">Add breed</span>)}

--- a/frontend/src/pages/pet-profile/tabs/VaccinationsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/VaccinationsTab.tsx
@@ -3,6 +3,7 @@ import { petsApi, PetVaccination } from '../../../api/client';
 import InlineEditForm from '../../../components/InlineEditForm';
 import { formatFlexibleDate } from '../../../components/FlexibleDateInput';
 import SourceDocumentLink from '../../../components/SourceDocumentLink';
+import EmptyState from '../../../components/EmptyState';
 import { useFieldToggle } from '../../../hooks/useFieldToggle';
 import { VACCINATION_FIELDS } from '../constants';
 
@@ -63,7 +64,7 @@ export default function VaccinationsTab({ petId, token, vaccinations, setVaccina
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Vaccinations</h3>
+        <h3 className="section-title">Vaccinations</h3>
         <button onClick={() => setShowForm(!showForm)} className="btn-primary text-sm">+ Add Vaccination</button>
       </div>
 
@@ -78,7 +79,7 @@ export default function VaccinationsTab({ petId, token, vaccinations, setVaccina
       )}
 
       {vaccinations.length === 0 ? (
-        <p className="text-gray-500 text-center py-8">No vaccinations recorded</p>
+        <EmptyState title="No vaccinations recorded" compact />
       ) : (
         <ul className="divide-y">
           {vaccinations.map(v => (
@@ -96,32 +97,32 @@ export default function VaccinationsTab({ petId, token, vaccinations, setVaccina
                     <div className="flex items-center gap-2">
                       <p className="font-medium">{v.name}</p>
                       {v.show_on_card && (
-                        <span className="text-[10px] bg-red-100 text-red-700 px-1.5 py-0.5 rounded font-semibold">ALERT</span>
+                        <span className="text-[10px] bg-danger-light text-danger px-1.5 py-0.5 rounded font-semibold">ALERT</span>
                       )}
                     </div>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-surface-500">
                       Administered: {formatFlexibleDate(v.administered_date, v.administered_date_precision)}
                     </p>
                     {v.expiration_date && (
-                      <p className={`text-sm ${isExpired(v.expiration_date) ? 'text-red-600' : 'text-gray-500'}`}>
+                      <p className={`text-sm ${isExpired(v.expiration_date) ? 'text-danger' : 'text-surface-500'}`}>
                         {isExpired(v.expiration_date) ? 'Expired' : 'Expires'}: {formatFlexibleDate(v.expiration_date, v.expiration_date_precision)}
                       </p>
                     )}
                     <SourceDocumentLink petId={petId} recordType="pet_vaccinations" recordId={v.id} onNavigateToReview={onNavigateToReview} />
                   </div>
                   <div className="flex gap-2">
-                    <button onClick={() => handleToggleShowOnCard(v)} className={`text-sm ${v.show_on_card ? 'text-red-600 hover:text-red-800' : 'text-gray-400 hover:text-gray-600'}`} title={v.show_on_card ? 'Remove from card' : 'Show on card'}>
+                    <button onClick={() => handleToggleShowOnCard(v)} className={`text-sm ${v.show_on_card ? 'text-danger hover:text-danger-dark' : 'text-surface-400 hover:text-surface-600'}`} title={v.show_on_card ? 'Remove from card' : 'Show on card'}>
                       {v.show_on_card ? '\u{1F514}' : '\u{1F515}'}
                     </button>
                     <button onClick={() => setEditingId(v.id)} className="text-navy hover:text-primary-800 text-sm">Edit</button>
                     {deletingId === v.id ? (
                       <>
-                        <span className="text-sm text-gray-500">Sure?</span>
-                        <button onClick={() => handleDelete(v.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
-                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                        <span className="text-sm text-surface-500">Sure?</span>
+                        <button onClick={() => handleDelete(v.id)} className="text-danger hover:text-danger-dark text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-surface-600 hover:text-navy text-sm">No</button>
                       </>
                     ) : (
-                      <button onClick={() => setDeletingId(v.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                      <button onClick={() => setDeletingId(v.id)} className="text-danger hover:text-danger-dark text-sm">Delete</button>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/pet-profile/tabs/VetsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/VetsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { petsApi, PetVet } from '../../../api/client';
 import InlineEditForm from '../../../components/InlineEditForm';
+import EmptyState from '../../../components/EmptyState';
 import { VET_FIELDS } from '../constants';
 
 export default function VetsTab({ petId, token, vets, setVets }: {
@@ -46,7 +47,7 @@ export default function VetsTab({ petId, token, vets, setVets }: {
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold">Veterinarians</h3>
+        <h3 className="section-title">Veterinarians</h3>
         <button onClick={() => setShowForm(!showForm)} className="btn-primary text-sm">+ Add Vet</button>
       </div>
 
@@ -61,7 +62,7 @@ export default function VetsTab({ petId, token, vets, setVets }: {
       )}
 
       {vets.length === 0 ? (
-        <p className="text-gray-500 text-center py-8">No veterinarians recorded</p>
+        <EmptyState title="No veterinarians recorded" compact />
       ) : (
         <ul className="divide-y">
           {vets.map(v => (
@@ -77,8 +78,8 @@ export default function VetsTab({ petId, token, vets, setVets }: {
                 <div className="flex justify-between items-start">
                   <div>
                     <p className="font-medium">{v.clinic_name} {v.is_primary && <span className="text-xs bg-navy-50 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
-                    {v.vet_name && <p className="text-sm text-gray-600">Dr. {v.vet_name}</p>}
-                    {v.phone && <p className="text-sm text-gray-500">{v.phone}</p>}
+                    {v.vet_name && <p className="text-sm text-surface-600">Dr. {v.vet_name}</p>}
+                    {v.phone && <p className="text-sm text-surface-500">{v.phone}</p>}
                   </div>
                   <div className="flex gap-2">
                     <button onClick={() => setEditingId(v.id)} className="text-navy hover:text-primary-800 text-sm">Edit</button>
@@ -87,12 +88,12 @@ export default function VetsTab({ petId, token, vets, setVets }: {
                     )}
                     {deletingId === v.id ? (
                       <>
-                        <span className="text-sm text-gray-500">Sure?</span>
-                        <button onClick={() => handleDelete(v.id)} className="text-red-600 hover:text-red-800 text-sm font-semibold">Yes</button>
-                        <button onClick={() => setDeletingId(null)} className="text-gray-600 hover:text-gray-800 text-sm">No</button>
+                        <span className="text-sm text-surface-500">Sure?</span>
+                        <button onClick={() => handleDelete(v.id)} className="text-danger hover:text-danger-dark text-sm font-semibold">Yes</button>
+                        <button onClick={() => setDeletingId(null)} className="text-surface-600 hover:text-navy text-sm">No</button>
                       </>
                     ) : (
-                      <button onClick={() => setDeletingId(v.id)} className="text-red-600 hover:text-red-800 text-sm">Delete</button>
+                      <button onClick={() => setDeletingId(v.id)} className="text-danger hover:text-danger-dark text-sm">Delete</button>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/pet-profile/tabs/VetsTab.tsx
+++ b/frontend/src/pages/pet-profile/tabs/VetsTab.tsx
@@ -64,7 +64,7 @@ export default function VetsTab({ petId, token, vets, setVets }: {
       {vets.length === 0 ? (
         <EmptyState title="No veterinarians recorded" compact />
       ) : (
-        <ul className="divide-y">
+        <ul className="divide-y divide-surface-100">
           {vets.map(v => (
             <li key={v.id} className="py-3">
               {editingId === v.id ? (
@@ -77,7 +77,7 @@ export default function VetsTab({ petId, token, vets, setVets }: {
               ) : (
                 <div className="flex justify-between items-start">
                   <div>
-                    <p className="font-medium">{v.clinic_name} {v.is_primary && <span className="text-xs bg-navy-50 text-primary-700 px-2 py-0.5 rounded">Primary</span>}</p>
+                    <p className="font-medium">{v.clinic_name} {v.is_primary && <span className="badge badge-navy">Primary</span>}</p>
                     {v.vet_name && <p className="text-sm text-surface-600">Dr. {v.vet_name}</p>}
                     {v.phone && <p className="text-sm text-surface-500">{v.phone}</p>}
                   </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -47,18 +47,20 @@ export default {
           DEFAULT: '#2E86DE',
           light: '#EBF5FB',
         },
-        // Surface grays
+        // Surface grays (warm cream/tan tones)
         surface: {
-          DEFAULT: '#F8F9FA',
-          50: '#F8F9FA',
-          100: '#F1F3F5',
-          200: '#E2E5E9',
-          300: '#CED4DA',
-          400: '#ADB5BD',
-          500: '#868E96',
-          600: '#5A6270',
-          700: '#3D4551',
+          DEFAULT: '#FAF9F7',
+          50: '#FAF9F7',
+          100: '#F5F3F0',
+          200: '#E8E5E0',
+          300: '#D5D0CA',
+          400: '#B5AFA6',
+          500: '#8C857C',
+          600: '#635C54',
+          700: '#463F38',
         },
+        // Warm accent background
+        warm: '#FFF8F3',
         // Keep backward compatibility with existing primary/accent references
         primary: {
           50: '#E8EDF4',
@@ -91,9 +93,9 @@ export default {
         lg: '12px',
       },
       boxShadow: {
-        'token-sm': '0 1px 2px rgba(27,42,74,0.05)',
-        'token-md': '0 2px 8px rgba(27,42,74,0.08)',
-        'token-lg': '0 4px 16px rgba(27,42,74,0.1)',
+        'token-sm': '0 1px 2px rgba(70,63,56,0.06)',
+        'token-md': '0 2px 8px rgba(70,63,56,0.08)',
+        'token-lg': '0 4px 16px rgba(70,63,56,0.10)',
       },
     },
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -36,6 +36,7 @@ export default {
         },
         warning: {
           DEFAULT: '#E6A817',
+          dark: 'var(--color-warning-dark)',
           light: '#FFF8E1',
         },
         success: {


### PR DESCRIPTION
## Summary

- **80 files** unified with the design token system across 3 phases, 13 tasks
- Replaced all Tailwind default palette classes (gray/red/green/blue/yellow) with design-token equivalents (surface/navy/danger/success/info/warning) across the entire frontend
- Converted inline `style={{}}` to Tailwind utilities in 7 core files (Layout, PetDetail, Dashboard, OverviewSection, EmergencyCardPreview, EmergencyCard, EmergencyCardView)
- Added `.page-title` / `.section-title` heading hierarchy classes with Fraunces font
- Normalized all spacing to 4px multiples in index.css component classes
- Fixed billing page blank render (ErrorBoundary + replaced missing `btn-outline`)
- Added `warning-dark` design token (#8B6914)
- Removed duplicate pet photo/name/breed block from OverviewSection
- Added breadcrumbs to AccountSettings, BillingSettings, Pricing
- Split `.card` (static) and `.card-interactive` (hover) classes
- Created reusable `EmptyState` component, replaced 8 inline patterns
- Collapsed action button text to icon-only on mobile
- Fixed pill nav fade gradient clipping
- Made emergency card preview collapsible on mobile
- Normalized EmergencyCard section header typography

## Test plan

- [ ] Verify all pages render correctly (Dashboard, PetDetail, Settings, Billing, Pricing)
- [ ] Verify billing page no longer renders blank
- [ ] Verify mobile: icon-only action buttons, pill nav not clipped, card preview toggle works
- [ ] Verify public card renders with correct fonts (Source Sans 3 body, Fraunces headings)
- [ ] Verify breadcrumbs on Settings, Billing, Pricing pages
- [ ] Verify Dashboard pet cards have hover effect, other cards do not
- [ ] Verify empty states render consistently across all pet-profile tabs
- [ ] Spot-check admin pages for correct token usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)