### PR TITLE
feat: pending invitation notifications on dashboard

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import adminAnalyticsRoutes from './routes/admin-analytics.js';
 import billingRoutes from './routes/billing.js';
 import subscriptionAdminRoutes from './routes/subscription-admin.js';
 import stripeWebhookRoutes from './routes/stripe-webhook.js';
+import invitationsRoutes from './routes/invitations.js';
 
 const app = express();
 
@@ -73,6 +74,7 @@ app.use('/api/pets', auditRoutes);        // Audit routes under /api/pets/:petId
 app.use('/api/public', publicRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/owners', ownersRoutes);
+app.use('/api/invitations', invitationsRoutes);
 app.use('/api', shareTokenRoutes);  // Share token routes under /api/pets/:petId/share-tokens
 app.use('/api/cms', cmsRoutes);     // CMS routes under /api/cms
 app.use('/api/admin/users', adminUsersRoutes);  // Admin users routes

--- a/backend/src/models/pet-owners.ts
+++ b/backend/src/models/pet-owners.ts
@@ -204,6 +204,31 @@ export async function deleteInvitation(invitationId: number, petId: number): Pro
   return true;
 }
 
+export interface PendingInvitationForUser {
+  id: number;
+  pet_id: number;
+  pet_name: string;
+  inviter_name: string;
+  role: PetRole;
+  invite_code: string;
+  expires_at: Date;
+  created_at: Date;
+}
+
+// Get pending invitations for a user by their email address
+export async function getPendingInvitationsForEmail(email: string): Promise<PendingInvitationForUser[]> {
+  return query<PendingInvitationForUser>(
+    `SELECT pi.id, pi.pet_id, p.name as pet_name, u.name as inviter_name,
+            pi.role, pi.invite_code, pi.expires_at, pi.created_at
+     FROM pet_invitations pi
+     JOIN pets p ON p.id = pi.pet_id
+     JOIN users u ON u.id = pi.invited_by
+     WHERE pi.email = $1 AND pi.accepted_at IS NULL AND pi.expires_at > CURRENT_TIMESTAMP
+     ORDER BY pi.created_at DESC`,
+    [email.toLowerCase()]
+  );
+}
+
 // Get all pets a user has access to (replaces the old findPetsByUserId)
 export async function getPetsForUser(userId: number): Promise<number[]> {
   const results = await query<{ pet_id: number }>(

--- a/backend/src/routes/invitations.ts
+++ b/backend/src/routes/invitations.ts
@@ -1,0 +1,18 @@
+import { Router, Response } from 'express';
+import { authenticate, AuthRequest } from '../middleware/auth.js';
+import { getPendingInvitationsForEmail } from '../models/pet-owners.js';
+
+const router = Router();
+
+// GET /api/invitations - Get pending invitations for the authenticated user
+router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const invitations = await getPendingInvitationsForEmail(req.user!.email);
+    res.json(invitations);
+  } catch (error) {
+    console.error('Error fetching pending invitations:', error);
+    res.status(500).json({ error: 'Failed to fetch pending invitations' });
+  }
+});
+
+export default router;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -870,6 +870,29 @@ export const documentsApi = {
     api.patch<DocumentUpload>(`/api/pets/${petId}/documents/uploads/${uploadId}/image-metadata`, data, token),
 };
 
+// Invitations Types
+export type PetRole = 'owner' | 'editor' | 'viewer';
+
+export interface PendingInvitation {
+  id: number;
+  pet_id: number;
+  pet_name: string;
+  inviter_name: string;
+  role: PetRole;
+  invite_code: string;
+  expires_at: string;
+  created_at: string;
+}
+
+// Invitations API
+export const invitationsApi = {
+  getMyPending: (token: string) =>
+    api.get<PendingInvitation[]>('/api/invitations', token),
+
+  accept: (inviteCode: string, token: string) =>
+    api.post<{ message: string; pet: Pet }>(`/api/owners/accept/${inviteCode}`, {}, token),
+};
+
 // Audit API
 export const auditApi = {
   // Get audit log for a pet

--- a/frontend/src/components/PendingInvitations.tsx
+++ b/frontend/src/components/PendingInvitations.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { invitationsApi, PendingInvitation } from '../api/client';
+
+interface Props {
+  onAccepted?: () => void;
+}
+
+export default function PendingInvitations({ onAccepted }: Props) {
+  const { token } = useAuth();
+  const [invitations, setInvitations] = useState<PendingInvitation[]>([]);
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    invitationsApi.getMyPending(token)
+      .then(data => {
+        setInvitations(data);
+        setLoaded(true);
+      })
+      .catch(() => {
+        setLoaded(true);
+      });
+  }, [token]);
+
+  const handleAccept = async (invitation: PendingInvitation) => {
+    if (!token) return;
+    try {
+      await invitationsApi.accept(invitation.invite_code, token);
+      setInvitations(prev => prev.filter(i => i.id !== invitation.id));
+      onAccepted?.();
+    } catch (err) {
+      console.error('Failed to accept invitation:', err);
+    }
+  };
+
+  const handleDismiss = (id: number) => {
+    setDismissed(prev => new Set(prev).add(id));
+  };
+
+  if (!loaded) return null;
+
+  const visible = invitations.filter(i => !dismissed.has(i.id));
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      <div className="bg-warm border border-surface-200 rounded-xl p-5">
+        <h2 className="section-title mb-3">Pending Invitations</h2>
+        {visible.map(invitation => (
+          <div
+            key={invitation.id}
+            className="flex items-center justify-between p-4 bg-white rounded-lg border border-surface-200 mb-2 last:mb-0"
+          >
+            <div>
+              <p className="text-base font-semibold text-navy">{invitation.pet_name}</p>
+              <p className="text-sm text-surface-600">
+                Invited by {invitation.inviter_name} as{' '}
+                {invitation.role.charAt(0).toUpperCase() + invitation.role.slice(1)}
+              </p>
+              <p className="text-xs text-surface-500">
+                Expires {new Date(invitation.expires_at).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </p>
+            </div>
+            <div className="flex items-center gap-3 ml-4 shrink-0">
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => handleAccept(invitation)}
+              >
+                Accept
+              </button>
+              <button
+                className="text-sm text-surface-500 hover:text-surface-700"
+                onClick={() => handleDismiss(invitation.id)}
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import {
 } from '../api/client';
 import { cmsApi } from '../api/cms';
 import AddPetModal from '../components/AddPetModal';
+import PendingInvitations from '../components/PendingInvitations';
 import UpgradeBanner from '../components/UpgradeBanner';
 import SpeciesAvatar from '../components/SpeciesAvatar';
 import EmptyState from '../components/EmptyState';
@@ -177,6 +178,8 @@ export default function Dashboard() {
       <div className="breadcrumb">
         <span className="current">Dashboard</span>
       </div>
+
+      <PendingInvitations onAccepted={loadPets} />
 
       {/* Header */}
       <div className="flex justify-between items-center mb-6">


### PR DESCRIPTION
## Summary
- Users with pending pet share invitations now see a warm-toned banner at the top of their Dashboard
- Each invitation shows pet name, inviter, role, expiration, with Accept and Dismiss buttons
- New RESTful `GET /api/invitations` endpoint returns pending invitations matched by authenticated user's email
- Accept wires into existing `POST /api/owners/accept/:inviteCode` — pet appears in grid immediately
- Dismiss is session-only (reappears on next login until accepted or expired)

## Changes
| File | Change |
|---|---|
| `backend/src/models/pet-owners.ts` | New `getPendingInvitationsForEmail()` + interface |
| `backend/src/routes/invitations.ts` | **New** — `GET /` route for pending invitations |
| `backend/src/index.ts` | Mount at `/api/invitations` |
| `frontend/src/api/client.ts` | New `invitationsApi` with `getMyPending` + `accept` |
| `frontend/src/components/PendingInvitations.tsx` | **New** — banner component |
| `frontend/src/pages/Dashboard.tsx` | Renders `<PendingInvitations>` above pet grid |

## Test plan
- [ ] Log in as a user who has pending invitations — banner should appear
- [ ] Verify pet name, inviter name, role, and expiration render correctly
- [ ] Click Accept — invitation disappears, pet appears in grid
- [ ] Click Dismiss — invitation disappears for the session
- [ ] Refresh page — dismissed invitations reappear, accepted ones don't
- [ ] Log in as a user with no invitations — no banner shown
- [ ] Verify expired invitations don't appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)